### PR TITLE
Refactor: use secp256k1jni directly without bitcoin-s-crypto

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,7 +190,7 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform)
       libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.16" % "provided",
       libraryDependencies += "org.bouncycastle" % "bcprov-jdk18on" % "1.79",
       libraryDependencies += "foundation.icon" % "blst-java" % "0.3.2",
-      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-crypto_2.13" % "1.9.9",
+      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-crypto_2.13" % "1.9.9" % "test",
       libraryDependencies += "org.bitcoin-s" % "bitcoin-s-secp256k1jni" % "1.9.9"
     )
     .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -188,10 +188,10 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform)
       Test / fork := true,
       // Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-S", "-8077211454138081902"),
       libraryDependencies += "org.slf4j" % "slf4j-simple" % "2.0.16" % "provided",
-      libraryDependencies += "org.bouncycastle" % "bcprov-jdk18on" % "1.79",
+      libraryDependencies += "org.bouncycastle" % "bcprov-jdk18on" % "1.80",
       libraryDependencies += "foundation.icon" % "blst-java" % "0.3.2",
-      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-crypto_2.13" % "1.9.9" % "test",
-      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-secp256k1jni" % "1.9.9"
+      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-crypto_2.13" % "1.9.10" % "test",
+      libraryDependencies += "org.bitcoin-s" % "bitcoin-s-secp256k1jni" % "1.9.10"
     )
     .jsSettings(
       // Add JS-specific settings here

--- a/jvm/src/main/scala/scalus/builtin/PlatformSpecific.scala
+++ b/jvm/src/main/scala/scalus/builtin/PlatformSpecific.scala
@@ -1,19 +1,17 @@
 package scalus.builtin
 
-import org.bitcoins.crypto.ECDigitalSignature
-import org.bitcoins.crypto.ECPublicKey
-import org.bitcoins.crypto.SchnorrDigitalSignature
-import org.bitcoins.crypto.SchnorrPublicKey
+import org.bitcoin.NativeSecp256k1
 import org.bouncycastle.crypto.digests.Blake2bDigest
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import org.bouncycastle.crypto.signers.Ed25519Signer
 import org.bouncycastle.jcajce.provider.digest.Keccak
 import org.bouncycastle.jcajce.provider.digest.SHA3
 import scalus.utils.Utils
-import scodec.bits.ByteVector
 import supranational.blst.P1
 import supranational.blst.P2
 import supranational.blst.PT
+
+import java.math.BigInteger
 
 object JVMPlatformSpecific extends JVMPlatformSpecific
 trait JVMPlatformSpecific extends PlatformSpecific {
@@ -47,10 +45,11 @@ trait JVMPlatformSpecific extends PlatformSpecific {
     ): Boolean = {
         if pk.length != 32 then
             throw new IllegalArgumentException(s"Invalid public key length ${pk.length}")
+        if !NativeSecp256k1.isValidPubKey(0x02 +: pk.bytes) then // parity byte
+            throw new IllegalArgumentException(s"Invalid public key ${pk}")
         if sig.length != 64 then
             throw new IllegalArgumentException(s"Invalid signature length ${sig.length}")
-        val signature = SchnorrDigitalSignature(ByteVector(sig.bytes))
-        SchnorrPublicKey(ByteVector(pk.bytes)).verify(ByteVector(msg.bytes), signature)
+        NativeSecp256k1.schnorrVerify(sig.bytes, msg.bytes, pk.bytes)
     }
 
     override def verifyEd25519Signature(pk: ByteString, msg: ByteString, sig: ByteString): Boolean =
@@ -72,15 +71,25 @@ trait JVMPlatformSpecific extends PlatformSpecific {
         pk: ByteString,
         msg: ByteString,
         sig: ByteString
-    ): Boolean =
-        if pk.length != 33 then
+    ): Boolean = {
+        if pk.length != 33 || !NativeSecp256k1.isValidPubKey(pk.bytes) then
             throw new IllegalArgumentException(s"Invalid public key length ${pk.length}")
         if msg.length != 32 then
             throw new IllegalArgumentException(s"Invalid message length ${msg.length}")
         if sig.length != 64 then
             throw new IllegalArgumentException(s"Invalid signature length ${sig.length}")
-        val signature = ECDigitalSignature.fromRS(ByteVector(sig.bytes))
-        ECPublicKey(ByteVector(pk.bytes)).verify(ByteVector(msg.bytes), signature)
+        val r = BigInt(new BigInteger(1, sig.bytes, 0, 32)) // avoid copying the array
+        val s = BigInt(new BigInteger(1, sig.bytes, 32, 32)) // avoid copying the array
+        val rsSize = r.toByteArray.length + s.toByteArray.length
+        val totalSize = 4 + rsSize
+        val signature = Array(
+          0x30.toByte,
+          totalSize.toByte,
+          0x2.toByte,
+          r.toByteArray.length.toByte
+        ) ++ r.toByteArray ++ Array(0x2.toByte, s.toByteArray.length.toByte) ++ s.toByteArray
+        NativeSecp256k1.verify(msg.bytes, signature, pk.bytes)
+    }
 
     // BLS12_381 operations
     override def bls12_381_G1_equal(p1: BLS12_381_G1_Element, p2: BLS12_381_G1_Element): Boolean = {


### PR DESCRIPTION
bitcoin-s-crypto dependency introduced conflicts with scodec for Scala 2.13 and 3. We don't really need it
