### PR TITLE
compile synthetic Obj.apply as a primary constructor

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -182,7 +182,8 @@ compile {
     val empty = State.Empty // simple constructor
     // Use `new` to create an instance
     val account = new Account(ByteString.empty, tuple._2) // access tuple fields
-    val active: State = new State.Active(account)
+    // or use a companion object apply method
+    val active: State = State.Active(account)
     val hash = account.hash // access case class fields
     // A simple pattern matching is supported
     // no guards, no type ascriptions.
@@ -279,7 +280,7 @@ val fromDataExample = compile {
     {
         given FromData[Account] = (d: Data) => {
             val args = unConstrData(d).snd
-            new Account(args.head.to[ByteString], args.tail.head.to[BigInt])
+            Account(args.head.to[ByteString], args.tail.head.to[BigInt])
         }
         val account = data.to[Account]
     }

--- a/jvm/src/test/scala/scalus/CompilerPluginToSIRSpec.scala
+++ b/jvm/src/test/scala/scalus/CompilerPluginToSIRSpec.scala
@@ -986,6 +986,23 @@ class CompilerPluginToSIRSpec extends AnyFunSuite with ScalaCheckPropertyChecks:
         )
     }
 
+    test("compile companion object apply as a primary constructor") {
+        val compiled = compile {
+            scalus.ledger.api.v1.PubKeyHash(hex"deadbeef")
+        }
+        assert(
+          compiled ==
+              Decl(
+                DataDecl("PubKeyHash", List(ConstrDecl("PubKeyHash", List("hash")))),
+                Constr(
+                  "PubKeyHash",
+                  DataDecl("PubKeyHash", List(ConstrDecl("PubKeyHash", List("hash")))),
+                  List(Const(Constant.ByteString(hex"deadbeef")))
+                )
+              )
+        )
+    }
+
     test("compile Tuple2 construction/matching") {
         val compiled = compile {
             type Pair = (Boolean, Boolean)

--- a/scalus-plugin/src/main/scala/scalus/CompilationError.scala
+++ b/scalus-plugin/src/main/scala/scalus/CompilationError.scala
@@ -20,14 +20,9 @@ case class SymbolNotFound(name: String, srcPos: SrcPos) extends CompilationError
            |Possible reasons and solutions:
            |  Make sure you added @Compile annotation to the object that contains '$name'.
            |
-           |  Maybe you're trying to create a case class instance, but forgot to add 'new'?
-           |  In Scalus you need to write 'new MyDataType(...)' instead of 'MyDataType(...)'
-           |
            |  Maybe '$name' is not intended to be used in Scalus scripts.
            |
            |  Maybe you used $name by accident?
-           |
-           |  If the '$name' is defined in another file, try adding scalacOptions += "-Yretain-trees" to your build.sbt.
            |
            |  It can be a bug in Scalus. Please report it or contact us via Discord.
            |""".stripMargin

--- a/shared/src/main/scala/scalus/prelude/Prelude.scala
+++ b/shared/src/main/scala/scalus/prelude/Prelude.scala
@@ -76,11 +76,11 @@ object List:
     extension [A](lst: List[A]) inline def !!(idx: BigInt): A = getByIndex(lst)(idx)
 
     @Ignore
-    def apply[A](args: A*): List[A] = args.foldRight(empty[A]) { case (a, b) => new Cons(a, b) }
+    def apply[A](args: A*): List[A] = args.foldRight(empty[A]) { case (a, b) => Cons(a, b) }
 
     @Ignore
     def from[A](i: IterableOnce[A]): List[A] = i.iterator.foldRight(empty[A]) { case (a, b) =>
-        new Cons(a, b)
+        Cons(a, b)
     }
 
     @Ignore
@@ -102,24 +102,24 @@ object List:
     }
 
     /** Creates a list with a single element */
-    def single[A](a: A): List[A] = new Cons(a, List.Nil)
+    def single[A](a: A): List[A] = Cons(a, List.Nil)
 
     /** Adds an element at the beginning of this list */
-    def cons[A](head: A, tail: List[A]): List[A] = new Cons(head, tail)
+    def cons[A](head: A, tail: List[A]): List[A] = Cons(head, tail)
 
     def append[A](lst1: List[A], lst2: List[A]): List[A] = lst1 match
         case Nil              => lst2
-        case Cons(head, tail) => new Cons(head, append(tail, lst2))
+        case Cons(head, tail) => Cons(head, append(tail, lst2))
 
     def map[A, B](lst: List[A])(f: A => B): List[B] = lst match
         case Nil              => List.Nil
-        case Cons(head, tail) => new Cons(f(head), List.map(tail)(f))
+        case Cons(head, tail) => Cons(f(head), List.map(tail)(f))
 
     def map2[A, B, C](a: List[A], b: List[B])(f: (A, B) => C): List[C] = {
         a match
             case List.Cons(h1, t1) =>
                 b match
-                    case List.Cons(h2, t2) => new List.Cons(f(h1, h2), map2(t1, t2)(f))
+                    case List.Cons(h2, t2) => List.Cons(f(h1, h2), map2(t1, t2)(f))
                     case _                 => List.Nil
             case _ => List.Nil
     }
@@ -127,7 +127,7 @@ object List:
     def filter[A](lst: List[A])(p: A => Boolean): List[A] = lst match
         case Nil => List.Nil
         case Cons(head, tail) =>
-            if p(head) then new Cons(head, List.filter(tail)(p)) else List.filter(tail)(p)
+            if p(head) then Cons(head, List.filter(tail)(p)) else List.filter(tail)(p)
 
     def findOrFail[A](lst: List[A])(p: A => Boolean): A = lst match
         case Nil              => throw new Exception("Not found")
@@ -135,7 +135,7 @@ object List:
 
     def find[A](lst: List[A])(p: A => Boolean): Maybe[A] = lst match
         case Nil              => Maybe.Nothing
-        case Cons(head, tail) => if p(head) then new Maybe.Just(head) else find(tail)(p)
+        case Cons(head, tail) => if p(head) then Maybe.Just(head) else find(tail)(p)
 
     def exists[A](lst: List[A])(p: A => Boolean): Boolean = find(lst)(p) match
         case Nothing => false
@@ -204,29 +204,29 @@ case class AssocMap[A, B](inner: List[(A, B)])
 object AssocMap {
     import List.*
     import Maybe.*
-    def empty[A, B]: AssocMap[A, B] = new AssocMap(List.empty[(A, B)])
-    def singleton[A, B](key: A, value: B): AssocMap[A, B] = new AssocMap(
+    def empty[A, B]: AssocMap[A, B] = AssocMap(List.empty[(A, B)])
+    def singleton[A, B](key: A, value: B): AssocMap[A, B] = AssocMap(
       List.cons((key, value), List.Nil)
     )
-    def fromList[A, B](lst: List[(A, B)]): AssocMap[A, B] = new AssocMap(lst)
+    def fromList[A, B](lst: List[(A, B)]): AssocMap[A, B] = AssocMap(lst)
     def toList[A, B](map: AssocMap[A, B]): List[(A, B)] = map.inner
     def lookup[A: Eq, B](map: AssocMap[A, B])(key: A): Maybe[B] =
         def go(lst: List[(A, B)]): Maybe[B] = lst match
             case Nil => Maybe.Nothing
             case Cons(pair, tail) =>
                 pair match
-                    case (k, v) => if k === key then new Maybe.Just(v) else go(tail)
+                    case (k, v) => if k === key then Maybe.Just(v) else go(tail)
         go(map.inner)
 
     def insert[A: Eq, B](map: AssocMap[A, B])(key: A, value: B): AssocMap[A, B] =
         def go(lst: List[(A, B)]): List[(A, B)] = lst match
-            case Nil => new List.Cons((key, value), List.Nil)
+            case Nil => List.Cons((key, value), List.Nil)
             case Cons(pair, tail) =>
                 pair match
                     case (k, v) =>
-                        if k === key then new List.Cons((key, value), tail)
-                        else new List.Cons(pair, go(tail))
-        new AssocMap(go(map.inner))
+                        if k === key then List.Cons((key, value), tail)
+                        else List.Cons(pair, go(tail))
+        AssocMap(go(map.inner))
 
     def delete[A: Eq, B](map: AssocMap[A, B])(key: A): AssocMap[A, B] =
         def go(lst: List[(A, B)]): List[(A, B)] = lst match
@@ -234,8 +234,8 @@ object AssocMap {
             case Cons(pair, tail) =>
                 pair match
                     case (k, v) =>
-                        if k === key then tail else new List.Cons(pair, go(tail))
-        new AssocMap(go(map.inner))
+                        if k === key then tail else List.Cons(pair, go(tail))
+        AssocMap(go(map.inner))
 
     def union[A: Eq, B, C](
         lhs: AssocMap[A, B],
@@ -248,20 +248,20 @@ object AssocMap {
                     case (k, v) =>
                         val maybeR = AssocMap.lookup(rhs)(k)
                         val these = maybeR match
-                            case Nothing => new These.This(v)
-                            case Just(r) => new These.These(v, r)
-                        new Cons((k, these), go(tail))
+                            case Nothing => These.This(v)
+                            case Just(r) => These.These(v, r)
+                        Cons((k, these), go(tail))
 
         val lhs1 = go(lhs.inner) // all left with corresponding right
 
         val rhsNotInLhs =
             List.filter(rhs.inner) { case (a, c) => !List.exists(lhs.inner)(p => p._1 === a) }
 
-        val rhsThat = List.map(rhsNotInLhs) { case (k, v) => (k, new These.That(v)) }
-        new AssocMap(List.append(lhs1, rhsThat))
+        val rhsThat = List.map(rhsNotInLhs) { case (k, v) => (k, These.That(v)) }
+        AssocMap(List.append(lhs1, rhsThat))
 
     def map[A, B, C](map: AssocMap[A, B])(f: ((A, B)) => (A, C)): AssocMap[A, C] =
-        new AssocMap(List.map(map.inner)(f))
+        AssocMap(List.map(map.inner)(f))
 
     def all[A, B](map: AssocMap[A, B])(f: ((A, B)) => Boolean): Boolean =
         List.all(map.inner)(f)

--- a/shared/src/test/scala/scalus/TutorialSpec.scala
+++ b/shared/src/test/scala/scalus/TutorialSpec.scala
@@ -66,7 +66,8 @@ val dataTypes = compile {
     val empty = State.Empty // simple constructor
     // Use `new` to create an instance
     val account = new Account(ByteString.empty, tuple._2) // access tuple fields
-    val active: State = new State.Active(account)
+    // or use a companion object apply method
+    val active: State = State.Active(account)
     val hash = account.hash // access case class fields
     // A simple pattern matching is supported
     // no guards, no type ascriptions.

--- a/shared/src/test/scala/scalus/prelude/AssocMapSpec.scala
+++ b/shared/src/test/scala/scalus/prelude/AssocMapSpec.scala
@@ -19,15 +19,15 @@ class AssocMapSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Arbitr
 
     test("isEmpty") {
         assert(List.isEmpty(List.empty))
-        assert(!List.isEmpty(new List.Cons(true, List.Nil)))
+        assert(!List.isEmpty(List.Cons(true, List.Nil)))
     }
 
     test("union") {
         val m1 = AssocMap.fromList(
-          new Cons((BigInt(1), BigInt(2)), new Cons((BigInt(0), BigInt(0)), List.Nil))
+          Cons((BigInt(1), BigInt(2)), Cons((BigInt(0), BigInt(0)), List.Nil))
         )
         val m2 = AssocMap.fromList(
-          new Cons((BigInt(1), BigInt(3)), new Cons((BigInt(3), BigInt(4)), List.Nil))
+          Cons((BigInt(1), BigInt(3)), Cons((BigInt(3), BigInt(4)), List.Nil))
         )
         val m3 = AssocMap.union(m1, m2)
         val compiled = Compiler.compile {

--- a/shared/src/test/scala/scalus/prelude/MaybeSpec.scala
+++ b/shared/src/test/scala/scalus/prelude/MaybeSpec.scala
@@ -21,9 +21,9 @@ class MaybeSpec extends AnyFunSuite with ScalaCheckPropertyChecks with Arbitrary
         assert((Nothing: Maybe[String]) === Nothing)
         assert(Just(BigInt(1)) === Just(BigInt(1)))
         assert(Just(BigInt(1)) !== Just(BigInt(2)))
-        assertEval(compile(new Just(true) === Nothing), false)
-        assertEval(compile(new Just(true) === new Just(true)), true)
-        assertEval(compile(new Just(true) !== new Just(true)), false)
+        assertEval(compile(Just(true) === Nothing), false)
+        assertEval(compile(Just(true) === Just(true)), true)
+        assertEval(compile(Just(true) !== Just(true)), false)
     }
 
     private def assertEval(sir: SIR, expected: Term) = {


### PR DESCRIPTION
Allow to create an instance of a data type using both a primary constructor and a synthetic `apply` method of a companion class:

```scala
case class State(a: BigInt)
val s = new State(1)
val n = State(1) // same as above
```