### PR TITLE
Better equality handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,9 @@
 
 ## Env setup with Nix
 
-Make sure that you have installed Nix package manager (see https://nixos.org/ ) and enabled `nix-command` and `flake` features and
- IOHK binary cache.
+Make sure that you have installed Nix package manager (see https://nixos.org/ ) and enabled `nix-command` and `flake`
+features and
+IOHK binary cache.
 
 Typical Nix config can looks like:
 
@@ -23,11 +24,9 @@ allow-import-from-derivation = true
 
 Usually you already have this setup if you have build cardano-node or cardano-cli locally.
 
-
 ```bash
 nix develop
 ```
-
 
 ## Build
 
@@ -52,8 +51,23 @@ Seq(s"-Xplugin:${jar.getAbsolutePath}", s"-Jdummy=${jar.lastModified}")
 This line should be commented out in scalusPlugin project settings:
 
 ```scala
-version := "0.6.2-SNAPSHOT",
+version := "0.6.2-SNAPSHOT"
+,
 ```
+
+### Debugging Scalus Plugin during compilation
+
+* Run sbt with the following command:
+
+```bash
+sbt -J-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 compile
+```
+
+This makes the compiler wait for a debugger to attach on port 5005.
+
+* Set Breakpoints in IntelliJ
+* In IntelliJ, create a Remote Debug configuration (host: localhost, port: 5005) and start it.
+* Once attached, resume execution to hit your breakpoints.
 
 ## Docusaurus
 

--- a/shared/src/main/scala/scalus/builtin/Data.scala
+++ b/shared/src/main/scala/scalus/builtin/Data.scala
@@ -36,4 +36,4 @@ object Data extends DataApi:
     case class B(value: ByteString) extends Data:
         override def toString: String = s"B(\"${value.toHex}\")"
 
-    val unit = Constr(0, immutable.Nil)
+    val unit: Data = Constr(0, immutable.Nil)


### PR DESCRIPTION
Show better compilation error messages for Any.== usage.
Fix wrong handling of `null` literal: Null <:< non-primitive types that caused issues