### PR TITLE
feat: better throw Exception compilation

### DIFF
--- a/jvm/src/test/scala/scalus/examples/MintingPolicyExampleSpec.scala
+++ b/jvm/src/test/scala/scalus/examples/MintingPolicyExampleSpec.scala
@@ -171,7 +171,7 @@ class MintingPolicyExampleSpec extends BaseValidatorSpec {
         val appliedValidator =
             validator $ hoskyMintTxOutRef.id.hash $ hoskyMintTxOutRef.idx $ evaledTokens
         val flatSize = Program.plutusV1(appliedValidator).flatEncoded.length
-        assert(flatSize == 2223)
+        assert(flatSize == 2294)
         performMintingPolicyValidatorChecks(appliedValidator)(withScriptContextV1)
     }
 
@@ -181,7 +181,7 @@ class MintingPolicyExampleSpec extends BaseValidatorSpec {
         val appliedValidator =
             validator $ hoskyMintTxOutRef.id.hash $ hoskyMintTxOutRef.idx $ evaledTokens
         val flatSize = Program.plutusV2(appliedValidator).flatEncoded.length
-        assert(flatSize == 2380)
+        assert(flatSize == 2451)
         performMintingPolicyValidatorChecks(appliedValidator)(withScriptContextV2)
     }
 
@@ -192,7 +192,7 @@ class MintingPolicyExampleSpec extends BaseValidatorSpec {
         val appliedValidator =
             validator $ hoskyMintTxOutRef.id.hash $ hoskyMintTxOutRef.idx $ evaledTokens
         val flatSize = Program.plutusV1(appliedValidator).flatEncoded.length
-        assert(flatSize == 1028)
+        assert(flatSize == 1026)
         performMintingPolicyValidatorChecks(appliedValidator)(withScriptContextV1)
     }
 }

--- a/scalus-plugin-tests/src/test/scala/scalus/CompilerPluginToSIRSpec.scala
+++ b/scalus-plugin-tests/src/test/scala/scalus/CompilerPluginToSIRSpec.scala
@@ -23,12 +23,15 @@ object Test {
     given Data.ToData[Test] = ToData.deriveCaseClass[Test](12)
 }
 
+class CustomError extends Exception("custom error")
+
 class CompilerPluginToSIRSpec extends AnyFunSuite with ScalaCheckPropertyChecks:
     val deadbeef = Constant.ByteString(hex"deadbeef")
 
     test("compile literals") {
         val sir = compile {
-            (new Test(1, "asdf"), false)._1.b
+            def err(msg: String) = throw new RuntimeException(msg)
+            err("test")
         }
         println(sir)
         println(sir.pretty.render(100))

--- a/shared/src/main/scala/scalus/ledger/api/v1/Contexts.scala
+++ b/shared/src/main/scala/scalus/ledger/api/v1/Contexts.scala
@@ -48,7 +48,7 @@ object FromDataInstances {
         if tag == BigInt(0) then IntervalBoundType.NegInf
         else if tag == BigInt(1) then new IntervalBoundType.Finite(unIData(pair.snd.head))
         else if tag == BigInt(2) then IntervalBoundType.PosInf
-        else throw new Exception(s"Unknown IntervalBoundType tag: $tag")
+        else throw new Exception("Unknown IntervalBoundType tag")
 
     given FromData[Credential] = (d: Data) =>
         val pair = unConstrData(d)
@@ -56,7 +56,7 @@ object FromDataInstances {
         val args = pair.snd
         if tag == BigInt(0) then new Credential.PubKeyCredential(fromData[PubKeyHash](args.head))
         else if tag == BigInt(1) then new Credential.ScriptCredential(unBData(args.head))
-        else throw new Exception(s"Unknown Credential tag: $tag")
+        else throw new Exception("Unknown Credential tag")
 
     given FromData[StakingCredential] =
         (d: Data) =>
@@ -97,7 +97,7 @@ object FromDataInstances {
             )
         else if tag == BigInt(5) then DCert.Genesis
         else if tag == BigInt(6) then DCert.Mir
-        else throw new Exception(s"Unknown DCert tag: $tag")
+        else throw new Exception("Unknown DCert tag")
 
     given FromData[ScriptPurpose] = (d: Data) =>
         val pair = unConstrData(d)
@@ -108,7 +108,7 @@ object FromDataInstances {
         else if tag == BigInt(2) then
             new ScriptPurpose.Rewarding(fromData[StakingCredential](args.head))
         else if tag == BigInt(3) then new ScriptPurpose.Certifying(fromData[DCert](args.head))
-        else throw new Exception(s"Unknown ScriptPurpose tag: $tag")
+        else throw new Exception("Unknown ScriptPurpose tag")
 
     given FromData[Address] = (d: Data) =>
         val args = unConstrData(d).snd


### PR DESCRIPTION
Compile a throw expression to SIR
1. throw new Exception("error msg") becomes SIR.Error("error msg")
 2. throw new CustomException becomes SIR.Error("CustomException")
 3. throw foo() becomes SIR.Error("foo()")
 4. inline def err(inline msg: String) = throw new RuntimeException(msg) err("test") becomes SIR.Error("test")