### PR TITLE
refactor: remove using PlatformSpecific from Buitlins

### DIFF
--- a/js/src/main/scala/scalus/builtin/PlatformSpecific.scala
+++ b/js/src/main/scala/scalus/builtin/PlatformSpecific.scala
@@ -80,6 +80,9 @@ private trait Secp256k1Schnorr extends js.Object {
         js.native
 }
 
+object Builtins extends AbstractBuiltins(using NodeJsPlatformSpecific)
+class Builtins(using ps: PlatformSpecific) extends AbstractBuiltins(using ps)
+
 trait NodeJsPlatformSpecific extends PlatformSpecific {
     extension (bs: ByteString)
         def toUint8Array: Uint8Array =

--- a/jvm/src/main/scala/scalus/builtin/PlatformSpecific.scala
+++ b/jvm/src/main/scala/scalus/builtin/PlatformSpecific.scala
@@ -12,6 +12,9 @@ import supranational.blst.PT
 
 import java.math.BigInteger
 
+object Builtins extends Builtins(using JVMPlatformSpecific)
+class Builtins(using ps: PlatformSpecific) extends AbstractBuiltins(using ps)
+
 object JVMPlatformSpecific extends JVMPlatformSpecific
 trait JVMPlatformSpecific extends PlatformSpecific {
     override def sha2_256(bs: ByteString): ByteString =

--- a/native/src/main/scala/scalus/builtin/PlatformSpecific.scala
+++ b/native/src/main/scala/scalus/builtin/PlatformSpecific.scala
@@ -281,6 +281,9 @@ object Secp256k1Builtins:
         ) == 1
     }
 
+object Builtins extends Builtins(using NativePlatformSpecific)
+class Builtins(using ps: PlatformSpecific) extends AbstractBuiltins(using ps)
+
 trait NativePlatformSpecific extends PlatformSpecific {
     override def sha2_256(bs: ByteString): ByteString =
         ByteString.unsafeFromArray(Sodium.sha256(bs.bytes))

--- a/scalus-plugin/src/main/scala/scalus/Macros.scala
+++ b/scalus-plugin/src/main/scala/scalus/Macros.scala
@@ -1,7 +1,6 @@
 package scalus
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Symbols
-import dotty.tools.dotc.core.Symbols.requiredModule
 import scalus.sir.SIR
 import scalus.sir.SIRBuiltins
 import scalus.uplc.DefaultFun
@@ -33,9 +32,11 @@ object Macros {
                 '{
                     given Context = $ctx
                     (
-                      requiredModule("scalus.builtin.Builtins").requiredMethod(${
-                          Expr(methodName)
-                      }),
+                      Symbols
+                          .requiredClass("scalus.builtin.Builtins")
+                          .requiredMethod(${
+                              Expr(methodName)
+                          }),
                       ${ Select.unique('{ SIRBuiltins }.asTerm, methodName).asExprOf[SIR.Builtin] }
                     )
                 }

--- a/shared/src/main/scala/scalus/builtin/Builtins.scala
+++ b/shared/src/main/scala/scalus/builtin/Builtins.scala
@@ -186,7 +186,7 @@ object PlatformSpecific:
           "93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"
         )
 
-object Builtins:
+private[builtin] abstract class AbstractBuiltins(using ps: PlatformSpecific):
     // Integers
     def addInteger(i1: BigInt, i2: BigInt): BigInt = i1 + i2
     def subtractInteger(i1: BigInt, i2: BigInt): BigInt = i1 - i2
@@ -248,22 +248,18 @@ object Builtins:
         if a.length <= b.length then true
         else false
     // Cryptography and hashes
-    def sha2_256(using ps: PlatformSpecific)(bs: ByteString): ByteString = ps.sha2_256(bs)
-    def sha3_256(using ps: PlatformSpecific)(bs: ByteString): ByteString = ps.sha3_256(bs)
-    def blake2b_256(using ps: PlatformSpecific)(bs: ByteString): ByteString = ps.blake2b_256(bs)
-    def blake2b_224(using ps: PlatformSpecific)(bs: ByteString): ByteString = ps.blake2b_224(bs)
-    def verifyEd25519Signature(using ps: PlatformSpecific)(
+    def sha2_256(bs: ByteString): ByteString = ps.sha2_256(bs)
+    def sha3_256(bs: ByteString): ByteString = ps.sha3_256(bs)
+    def blake2b_256(bs: ByteString): ByteString = ps.blake2b_256(bs)
+    def blake2b_224(bs: ByteString): ByteString = ps.blake2b_224(bs)
+    def verifyEd25519Signature(
         pk: ByteString,
         msg: ByteString,
         sig: ByteString
     ): Boolean = ps.verifyEd25519Signature(pk, msg, sig)
-    def verifyEcdsaSecp256k1Signature(using
-        ps: PlatformSpecific
-    )(pk: ByteString, msg: ByteString, sig: ByteString): Boolean =
+    def verifyEcdsaSecp256k1Signature(pk: ByteString, msg: ByteString, sig: ByteString): Boolean =
         ps.verifyEcdsaSecp256k1Signature(pk, msg, sig)
-    def verifySchnorrSecp256k1Signature(using
-        ps: PlatformSpecific
-    )(pk: ByteString, msg: ByteString, sig: ByteString): Boolean =
+    def verifySchnorrSecp256k1Signature(pk: ByteString, msg: ByteString, sig: ByteString): Boolean =
         ps.verifySchnorrSecp256k1Signature(pk, msg, sig)
 
     // Strings
@@ -689,33 +685,24 @@ object Builtins:
 
     def bls12_381_scalar_period: BigInt = PlatformSpecific.bls12_381_scalar_period
 
-    def bls12_381_G1_equal(using
-        ps: PlatformSpecific
-    )(p1: BLS12_381_G1_Element, p2: BLS12_381_G1_Element): Boolean =
+    def bls12_381_G1_equal(p1: BLS12_381_G1_Element, p2: BLS12_381_G1_Element): Boolean =
         ps.bls12_381_G1_equal(p1, p2)
 
-    def bls12_381_G1_add(using
-        ps: PlatformSpecific
-    )(p1: BLS12_381_G1_Element, p2: BLS12_381_G1_Element): BLS12_381_G1_Element =
+    def bls12_381_G1_add(p1: BLS12_381_G1_Element, p2: BLS12_381_G1_Element): BLS12_381_G1_Element =
         ps.bls12_381_G1_add(p1, p2)
 
-    def bls12_381_G1_scalarMul(using
-        ps: PlatformSpecific
-    )(s: BigInt, p: BLS12_381_G1_Element): BLS12_381_G1_Element = ps.bls12_381_G1_scalarMul(s, p)
+    def bls12_381_G1_scalarMul(s: BigInt, p: BLS12_381_G1_Element): BLS12_381_G1_Element =
+        ps.bls12_381_G1_scalarMul(s, p)
 
-    def bls12_381_G1_neg(using ps: PlatformSpecific)(
-        p: BLS12_381_G1_Element
-    ): BLS12_381_G1_Element = ps.bls12_381_G1_neg(p)
+    def bls12_381_G1_neg(p: BLS12_381_G1_Element): BLS12_381_G1_Element = ps.bls12_381_G1_neg(p)
 
-    def bls12_381_G1_compress(using ps: PlatformSpecific)(p: BLS12_381_G1_Element): ByteString =
+    def bls12_381_G1_compress(p: BLS12_381_G1_Element): ByteString =
         ps.bls12_381_G1_compress(p)
 
-    def bls12_381_G1_uncompress(using ps: PlatformSpecific)(bs: ByteString): BLS12_381_G1_Element =
+    def bls12_381_G1_uncompress(bs: ByteString): BLS12_381_G1_Element =
         ps.bls12_381_G1_uncompress(bs)
 
-    def bls12_381_G1_hashToGroup(using
-        ps: PlatformSpecific
-    )(bs: ByteString, dst: ByteString): BLS12_381_G1_Element =
+    def bls12_381_G1_hashToGroup(bs: ByteString, dst: ByteString): BLS12_381_G1_Element =
         ps.bls12_381_G1_hashToGroup(bs, dst)
 
     /** The compressed form of the point at infinity in G1, 48 bytes long.
@@ -725,33 +712,25 @@ object Builtins:
     def bls12_381_G1_compressed_generator: ByteString =
         PlatformSpecific.bls12_381_G1_compressed_generator
 
-    def bls12_381_G2_equal(using
-        ps: PlatformSpecific
-    )(p1: BLS12_381_G2_Element, p2: BLS12_381_G2_Element): Boolean =
+    def bls12_381_G2_equal(p1: BLS12_381_G2_Element, p2: BLS12_381_G2_Element): Boolean =
         ps.bls12_381_G2_equal(p1, p2)
 
-    def bls12_381_G2_add(using
-        ps: PlatformSpecific
-    )(p1: BLS12_381_G2_Element, p2: BLS12_381_G2_Element): BLS12_381_G2_Element =
+    def bls12_381_G2_add(p1: BLS12_381_G2_Element, p2: BLS12_381_G2_Element): BLS12_381_G2_Element =
         ps.bls12_381_G2_add(p1, p2)
 
-    def bls12_381_G2_scalarMul(using
-        ps: PlatformSpecific
-    )(s: BigInt, p: BLS12_381_G2_Element): BLS12_381_G2_Element = ps.bls12_381_G2_scalarMul(s, p)
+    def bls12_381_G2_scalarMul(s: BigInt, p: BLS12_381_G2_Element): BLS12_381_G2_Element =
+        ps.bls12_381_G2_scalarMul(s, p)
 
-    def bls12_381_G2_neg(using ps: PlatformSpecific)(
-        p: BLS12_381_G2_Element
-    ): BLS12_381_G2_Element = ps.bls12_381_G2_neg(p)
+    def bls12_381_G2_neg(p: BLS12_381_G2_Element): BLS12_381_G2_Element = ps.bls12_381_G2_neg(p)
 
-    def bls12_381_G2_compress(using ps: PlatformSpecific)(p: BLS12_381_G2_Element): ByteString =
+    def bls12_381_G2_compress(p: BLS12_381_G2_Element): ByteString =
         ps.bls12_381_G2_compress(p)
 
-    def bls12_381_G2_uncompress(using ps: PlatformSpecific)(bs: ByteString): BLS12_381_G2_Element =
+    def bls12_381_G2_uncompress(bs: ByteString): BLS12_381_G2_Element =
         ps.bls12_381_G2_uncompress(bs)
 
-    def bls12_381_G2_hashToGroup(using
-        ps: PlatformSpecific
-    )(bs: ByteString, dst: ByteString): BLS12_381_G2_Element = ps.bls12_381_G2_hashToGroup(bs, dst)
+    def bls12_381_G2_hashToGroup(bs: ByteString, dst: ByteString): BLS12_381_G2_Element =
+        ps.bls12_381_G2_hashToGroup(bs, dst)
 
     /** The compressed form of the point at infinity in G2, 96 bytes long.
       */
@@ -760,23 +739,19 @@ object Builtins:
     def bls12_381_G2_compressed_generator: ByteString =
         PlatformSpecific.bls12_381_G2_compressed_generator
 
-    def bls12_381_millerLoop(using ps: PlatformSpecific)(
+    def bls12_381_millerLoop(
         p1: BLS12_381_G1_Element,
         p2: BLS12_381_G2_Element
     ): BLS12_381_MlResult =
         ps.bls12_381_millerLoop(p1, p2)
 
-    def bls12_381_mulMlResult(using
-        ps: PlatformSpecific
-    )(r1: BLS12_381_MlResult, r2: BLS12_381_MlResult): BLS12_381_MlResult =
+    def bls12_381_mulMlResult(r1: BLS12_381_MlResult, r2: BLS12_381_MlResult): BLS12_381_MlResult =
         ps.bls12_381_mulMlResult(r1, r2)
 
-    def bls12_381_finalVerify(using
-        ps: PlatformSpecific
-    )(p1: BLS12_381_MlResult, p2: BLS12_381_MlResult): Boolean =
+    def bls12_381_finalVerify(p1: BLS12_381_MlResult, p2: BLS12_381_MlResult): Boolean =
         ps.bls12_381_finalVerify(p1, p2)
 
-    def keccak_256(using ps: PlatformSpecific)(bs: ByteString): ByteString =
+    def keccak_256(bs: ByteString): ByteString =
         ps.keccak_256(bs)
 
     /** Hashing primitive Ripemd_160 for ByteStrings.
@@ -791,7 +766,7 @@ object Builtins:
       * @return
       *   The result of the Ripemd_160 hash function.
       */
-    def ripemd_160(using ps: PlatformSpecific)(byteString: ByteString): ByteString =
+    def ripemd_160(byteString: ByteString): ByteString =
         ps.ripemd_160(byteString)
 
 private object UTF8Decoder {

--- a/shared/src/main/scala/scalus/examples/Groth16.scala
+++ b/shared/src/main/scala/scalus/examples/Groth16.scala
@@ -12,7 +12,6 @@ import scalus.builtin.Data.ToData
 import scalus.builtin.FromData
 import scalus.builtin.ToData
 import scalus.prelude.*
-import scalus.builtin.given
 
 /** Groth16 Zero-Knowledge Proof Verification Implementation
   *

--- a/shared/src/main/scala/scalus/examples/PreimageValidator.scala
+++ b/shared/src/main/scala/scalus/examples/PreimageValidator.scala
@@ -6,7 +6,6 @@ import scalus.builtin.Builtins.*
 import scalus.builtin.ByteString
 import scalus.builtin.FromDataInstances.given
 import scalus.builtin.Data
-import scalus.builtin.given
 import scalus.ledger.api.v2.*
 import scalus.ledger.api.v2.FromDataInstances.given
 import scalus.prelude.List

--- a/shared/src/test/scala/scalus/TutorialSpec.scala
+++ b/shared/src/test/scala/scalus/TutorialSpec.scala
@@ -11,7 +11,6 @@ import scalus.builtin.Data.FromData
 import scalus.builtin.Data.fromData
 import scalus.builtin.FromData
 import scalus.builtin.FromDataInstances.given
-import scalus.builtin.given
 import scalus.ledger.api.PlutusLedgerLanguage
 import scalus.prelude.Prelude.===
 import scalus.prelude.Prelude.given


### PR DESCRIPTION
BREAKING CHANGE: remove using PlatformSpecific from Buitlins. This simplifies usage of Builtins yet still allows to use custom PlatformSpecific implementations. This removes special treatment of PlatformSpecific arguments in SIRCompiler.