### PR TITLE
refactor: move methods from TermDSL to Term

### DIFF
--- a/examples-js/src/main/scala/scalus/MintingPolicyJS.scala
+++ b/examples-js/src/main/scala/scalus/MintingPolicyJS.scala
@@ -7,7 +7,7 @@ import scalus.examples.MintingPolicy
 import scalus.prelude.AssocMap
 import scalus.sir.SIR
 import scalus.uplc.Term
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.eval.PlutusVM
 import scalus.builtin.given
 

--- a/js/src/test/scala/scalus/examples/Groth16Spec.scala
+++ b/js/src/test/scala/scalus/examples/Groth16Spec.scala
@@ -13,7 +13,6 @@ import scalus.examples.Groth16.*
 import scalus.prelude.List
 import scalus.uplc.Constant
 import scalus.uplc.Term
-import scalus.uplc.TermDSL.*
 import scalus.uplc.TermDSL.given
 import scalus.uplc.eval.PlutusVM
 

--- a/jvm/src/test/scala/scalus/examples/Groth16Spec.scala
+++ b/jvm/src/test/scala/scalus/examples/Groth16Spec.scala
@@ -13,7 +13,6 @@ import scalus.examples.Groth16.*
 import scalus.prelude.List
 import scalus.uplc.Constant
 import scalus.uplc.Term
-import scalus.uplc.TermDSL.*
 import scalus.uplc.TermDSL.given
 import scalus.uplc.eval.PlutusVM
 

--- a/jvm/src/test/scala/scalus/examples/MintingPolicyExampleSpec.scala
+++ b/jvm/src/test/scala/scalus/examples/MintingPolicyExampleSpec.scala
@@ -11,7 +11,7 @@ import scalus.ledger.api.v2
 import scalus.prelude.Maybe.*
 import scalus.prelude.*
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.*
 
 import scala.language.implicitConversions

--- a/jvm/src/test/scala/scalus/ledger/api/v1/ScriptContextV1DataSerializationSpec.scala
+++ b/jvm/src/test/scala/scalus/ledger/api/v1/ScriptContextV1DataSerializationSpec.scala
@@ -150,7 +150,7 @@ class ScriptContextV1DataSerializationSpec extends BaseValidatorSpec:
 
     test("deserialize ScriptContext V1 using Scalus") {
         import scalus.ledger.api.v1.ToDataInstances.given
-        import scalus.uplc.TermDSL.{*, given}
+        import scalus.uplc.TermDSL.given
         given PlutusVM = PlutusVM.makePlutusV1VM(machineParamsV1)
         val applied = Program((1, 0, 0), scalusDeserializerV1 $ scriptContextV1.toData)
 
@@ -179,7 +179,7 @@ class ScriptContextV1DataSerializationSpec extends BaseValidatorSpec:
 
     test("deserialize ScriptContext V2 using Scalus") {
         import scalus.ledger.api.v2.ToDataInstances.given
-        import scalus.uplc.TermDSL.{*, given}
+        import scalus.uplc.TermDSL.given
         val applied = Program((1, 0, 0), scalusDeserializerV2 $ scriptContextV2.toData)
 
         assertSameResult(Expected.SuccessSame)(applied)

--- a/jvm/src/test/scala/scalus/uplc/eval/PlutusVMSpec.scala
+++ b/jvm/src/test/scala/scalus/uplc/eval/PlutusVMSpec.scala
@@ -5,8 +5,7 @@ import scalus.builtin.given
 import scalus.uplc.Constant
 import scalus.uplc.DeBruijn
 import scalus.uplc.Program
-import scalus.uplc.Term.Const
-import scalus.uplc.TermDSL.*
+import scalus.uplc.Term.*
 
 class PlutusVMSpec extends AnyFunSuiteLike {
     private val v2vm = PlutusVM.makePlutusV2VM()

--- a/jvm/src/test/scala/scalus/uplc/transform/CaseConstrApplySpec.scala
+++ b/jvm/src/test/scala/scalus/uplc/transform/CaseConstrApplySpec.scala
@@ -7,7 +7,6 @@ import scalus.builtin.ByteString.*
 import scalus.builtin.{ByteString, given}
 import scalus.uplc.Constant
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{vr, λ}
 import scalus.uplc.eval.ExBudget.given
 import scalus.uplc.eval.Result.Success
 import scalus.uplc.eval.{ExBudget, PlutusVM}

--- a/jvm/src/test/scala/scalus/uplc/transform/ForcedBuiltinsExtractorSpec.scala
+++ b/jvm/src/test/scala/scalus/uplc/transform/ForcedBuiltinsExtractorSpec.scala
@@ -6,7 +6,7 @@ import scalus.builtin.Builtins.*
 import scalus.uplc.Constant
 import scalus.uplc.DefaultUni.asConstant
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.Constant.given
 import scalus.uplc.DefaultFun
 import scalus.uplc.DefaultUni.Bool

--- a/jvm/src/test/scala/scalus/utils/UtilsSpec.scala
+++ b/jvm/src/test/scala/scalus/utils/UtilsSpec.scala
@@ -5,10 +5,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scalus.*
 import scalus.ledger.api.PlutusLedgerLanguage
-import scalus.uplc.ArbitraryInstances
-import scalus.uplc.Program
-import scalus.uplc.Term
-import scalus.uplc.TermDSL.*
+import scalus.uplc.{ArbitraryInstances, Program, Term}
+import scalus.uplc.Term.*
 
 import java.nio.file.Files
 

--- a/shared/src/main/scala/scalus/sir/PrettyPrinter.scala
+++ b/shared/src/main/scala/scalus/sir/PrettyPrinter.scala
@@ -10,7 +10,6 @@ import scalus.uplc.Constant
 import scalus.uplc.DefaultFun
 import scalus.uplc.DefaultUni
 import scalus.uplc.Term
-import scalus.uplc.TermDSL
 import scalus.utils.Utils
 
 /** Pretty printers.
@@ -295,7 +294,7 @@ object PrettyPrinter:
                     + kw("lam") & text(name) / pretty(term, style).indent(2)
                     + char(')').styled(Fg.colorCode(color))
             case a @ Apply(f, arg) =>
-                val (t, args) = TermDSL.applyToList(a)
+                val (t, args) = a.applyToList
                 val color = nextBracketColor()
                 intercalate(lineOrSpace, (t :: args).map(pretty(_, style)))
                     .tightBracketBy(

--- a/shared/src/main/scala/scalus/sir/SimpleSirToUplcLowering.scala
+++ b/shared/src/main/scala/scalus/sir/SimpleSirToUplcLowering.scala
@@ -3,7 +3,6 @@ package sir
 
 import scalus.sir.Recursivity.*
 import scalus.sir.SIR.Pattern
-import scalus.uplc.TermDSL.*
 import scalus.uplc.*
 
 import scala.annotation.tailrec

--- a/shared/src/main/scala/scalus/sir/SimpleSirToUplcV3Lowering.scala
+++ b/shared/src/main/scala/scalus/sir/SimpleSirToUplcV3Lowering.scala
@@ -3,9 +3,9 @@ package sir
 
 import scalus.sir.Recursivity.*
 import scalus.sir.SIR.Pattern
-import scalus.uplc.DefaultFun.*
-import scalus.uplc.TermDSL.*
 import scalus.uplc.*
+import scalus.uplc.DefaultFun.*
+import scalus.uplc.Term.*
 
 import scala.annotation.tailrec
 import scala.collection.mutable.HashMap

--- a/shared/src/main/scala/scalus/uplc/Expr.scala
+++ b/shared/src/main/scala/scalus/uplc/Expr.scala
@@ -13,7 +13,7 @@ trait Delayed[+A]
 case class Expr[+A](term: Term)
 
 object ExprBuilder:
-    import TermDSL.*
+    import Term.*
 
     trait Unlift[A]:
         def unlift: Expr[Data => A]

--- a/shared/src/main/scala/scalus/uplc/TermDSL.scala
+++ b/shared/src/main/scala/scalus/uplc/TermDSL.scala
@@ -6,6 +6,7 @@ import scalus.builtin.Data.*
 import scala.collection.immutable
 
 object TermDSL:
+    @deprecated("Use Term.applyToList instead", "0.9.0")
     def applyToList(app: Term): (Term, immutable.List[Term]) =
         app match
             case Term.Apply(f, arg) =>
@@ -13,16 +14,26 @@ object TermDSL:
                 (f1, args :+ arg)
             case f => (f, Nil)
 
+    @deprecated("Use Term.λ instead", "0.9.0")
     def λ(names: String*)(term: Term): Term = lam(names*)(term)
+    @deprecated("Use Term.λλ instead", "0.9.0")
     def λλ(name: String)(f: Term => Term): Term = lam(name)(f(vr(name)))
+    @deprecated("Use Term.lam instead", "0.9.0")
     def lam(names: String*)(term: Term): Term = names.foldRight(term)(Term.LamAbs(_, _))
+    @deprecated("Use Term.vr instead", "0.9.0")
     def vr(name: String): Term = Term.Var(NamedDeBruijn(name))
+
     extension (term: Term)
+        @deprecated("Use Term.$ instead", "0.9.0")
         infix def $(rhs: Term): Term = Term.Apply(term, rhs)
+        @deprecated("Use Term.asTerm instead", "0.9.0")
         def unary_! : Term = Term.Force(term)
+        @deprecated("Use Term.asTerm instead", "0.9.0")
         def unary_~ : Term = Term.Delay(term)
 
-    extension (sc: StringContext) def vr(args: Any*): Term = Term.Var(NamedDeBruijn(sc.parts.head))
+    extension (sc: StringContext)
+        @deprecated("Use Term.vr instead", "0.9.0")
+        def vr(args: Any*): Term = Term.Var(NamedDeBruijn(sc.parts.head))
 
     given Conversion[DefaultFun, Term] with
         def apply(bn: DefaultFun): Term = Term.Builtin(bn)
@@ -31,6 +42,7 @@ object TermDSL:
         def apply(c: A): Term = Term.Const(summon[Constant.LiftValue[A]].lift(c))
 
     extension [A: Constant.LiftValue](a: A)
+        @deprecated("Use Term.asTerm instead", "0.9.0")
         def asTerm: Term = Term.Const(summon[Constant.LiftValue[A]].lift(a))
 
     given Conversion[Constant, Term] with

--- a/shared/src/main/scala/scalus/uplc/transform/ForcedBuiltinsExtractor.scala
+++ b/shared/src/main/scala/scalus/uplc/transform/ForcedBuiltinsExtractor.scala
@@ -5,7 +5,6 @@ import scalus.uplc.Meaning
 import scalus.uplc.NamedDeBruijn
 import scalus.uplc.Term
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.*
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/shared/src/test/scala/scalus/sir/SimpleSirToUplcLoweringSpec.scala
+++ b/shared/src/test/scala/scalus/sir/SimpleSirToUplcLoweringSpec.scala
@@ -12,7 +12,8 @@ import scalus.uplc.DefaultFun
 import scalus.uplc.DefaultFun.*
 import scalus.uplc.DefaultUni.asConstant
 import scalus.uplc.Term
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.Term.*
+import scalus.uplc.TermDSL.given
 
 import scala.language.implicitConversions
 

--- a/shared/src/test/scala/scalus/uplc/CekBuiltinsSpec.scala
+++ b/shared/src/test/scala/scalus/uplc/CekBuiltinsSpec.scala
@@ -11,7 +11,7 @@ import scalus.uplc.Constant.Pair
 import scalus.uplc.DefaultFun.*
 import scalus.uplc.DefaultUni.asConstant
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.eval.*
 
 import scala.language.implicitConversions

--- a/shared/src/test/scala/scalus/uplc/TermDSLSpec.scala
+++ b/shared/src/test/scala/scalus/uplc/TermDSLSpec.scala
@@ -5,7 +5,8 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scalus.*
 import scalus.builtin.ByteString
 import scalus.uplc.DefaultUni.asConstant
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.Term.*
+import scalus.uplc.TermDSL.given
 
 import scala.language.implicitConversions
 

--- a/shared/src/test/scala/scalus/uplc/transform/EtaReduceSpec.scala
+++ b/shared/src/test/scala/scalus/uplc/transform/EtaReduceSpec.scala
@@ -5,7 +5,7 @@ import scalus.*
 import scalus.uplc.DefaultFun.*
 import scalus.uplc.Term
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.transform.EtaReduce.etaReduce
 
 import scala.language.implicitConversions

--- a/shared/src/test/scala/scalus/uplc/transform/InlinerSpec.scala
+++ b/shared/src/test/scala/scalus/uplc/transform/InlinerSpec.scala
@@ -2,7 +2,7 @@ package scalus.uplc
 package transform
 
 import scalus.uplc.Term.*
-import scalus.uplc.TermDSL.{*, given}
+import scalus.uplc.TermDSL.given
 import scalus.uplc.Constant.given
 import DefaultFun.*
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
BREAKING CHANGE: but it's easy to fix by removing import TermDSL.* and using Term.* instead