### PR TITLE
Fix message for WrongOutputType

### DIFF
--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionBuilder.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionBuilder.scala
@@ -1937,7 +1937,6 @@ object StepError {
                 s"UTxO: $utxo"
     }
 
-
     case class WrongCredentialType(
         action: Operation,
         expectedType: WitnessKind,


### PR DESCRIPTION
The way this is used in `useSpend`, it doesn't always correspond to a PKH.