### PR TITLE
Fix non-commutative mutators in CardanoMutator

### DIFF
--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/rules/CardanoMutator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/rules/CardanoMutator.scala
@@ -20,13 +20,24 @@ object CardanoMutator extends STS.Mutator {
             .map(v => v.name -> v)
             .toMap
 
-    val allMutators: Map[String, STS.Mutator] =
-        TraitObjectScanner
-            .findImplementors[STS.Mutator](packageName)
-            .view
-            .filter(_.name != this.name) // Exclude self to prevent infinite recursion
-            .map(v => v.name -> v)
-            .toMap
+    val allMutators: Map[String, STS.Mutator] = {
+        // FIXME: The TraitObjectScanner is non-deterministic; it can return the mutators in different orders.
+        // The mutators aren't commutative, so this is an issue.
+//        TraitObjectScanner
+//            .findImplementors[STS.Mutator](packageName)
+//            .view
+//            .filter(_.name != this.name) // Exclude self to prevent infinite recursion
+//            .map(v => v.name -> v)
+//            .toMap
+        // QUESTION: Should we add the outputs before or after running the plutus scripts transaction mutator?
+        // Does it matter?
+        Map(
+          "AddOutputsToUtxoMutator" -> AddOutputsToUtxoMutator,
+          "PlutusScriptsTransactionMutator" -> PlutusScriptsTransactionMutator,
+          "FeeMutator" -> FeeMutator,
+          "RemoveInputsFromUtxoMutator" -> RemoveInputsFromUtxoMutator
+        )
+    }
 
     val allSTSs: Map[String, STS] = allValidators ++ allMutators
 }


### PR DESCRIPTION
The `TraitObjectScanner` can return the mutators in different orders depending on the run.

I _think_ this results in the `PlutusScriptsTransactionMutator` failing intermittently if it is executed after the `RemoveInputsFromUtxoMutator` and there is a reference script in the spent inputs.

I put `AddOutputsToUtxoMutator` prior to the `PlutusScriptsTransactionMutator` for the same reason -- I _think_ that the PlutusScripts mutator should have access to reference scripts in the outputs as well, but I'm not certain if this is correct.