### PR TITLE
add 'validationSlot' to transaction builders

### DIFF
--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionBuilder.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionBuilder.scala
@@ -340,15 +340,17 @@ object TransactionBuilder {
         /** Conversion help to Scalus [[scalus.cardano.ledger.Utxos]] */
         def getUtxos: Utxos = this.resolvedUtxos.utxos
 
-        /** Validate a context according so a set of ledger rules */
+        /** Validate a context according to a set of ledger rules */
         def validate(
             validators: Seq[Validator],
-            protocolParams: ProtocolParams
+            protocolParams: ProtocolParams,
+            validationSlot: Long,
         ): Either[TransactionException, Context] = {
+            // FIXME: this should either be passed explicitly as "validationCertState" or built in the builder context
             val certState = CertState.empty
             val context = SContext(
               this.transaction.body.value.fee,
-              UtxoEnv(1L, protocolParams, certState, network)
+              UtxoEnv(validationSlot, protocolParams, certState, network)
             )
             val state = SState(this.getUtxos, certState)
             validators
@@ -363,6 +365,7 @@ object TransactionBuilder {
         def finalizeContext(
             protocolParams: ProtocolParams,
             diffHandler: DiffHandler,
+            validationSlot: Long,
             evaluator: PlutusScriptEvaluator,
             validators: Seq[Validator]
         ): Either[SomeBuildError, Context] = {
@@ -393,7 +396,7 @@ object TransactionBuilder {
                     .map(BalancingError(_, this))
 
                 validatedCtx <- balancedCtx
-                    .validate(validators, protocolParams)
+                    .validate(validators, protocolParams, validationSlot)
                     .left
                     .map(ValidationError(_, this))
 


### PR DESCRIPTION
The previous version hard-coded the slot to 1 during ledger rules validation. 

It still defaults to `1L` in the TxBuilder so as not to break compatibility, but it should probably be updated.