### PR TITLE
feat: scalus plugin + example ejector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -521,8 +521,7 @@ lazy val scalusExamples = crossProject(JSPlatform, JVMPlatform)
     .in(file("scalus-examples"))
     .dependsOn(scalus, scalusTestkit)
     .disablePlugins(MimaPlugin) // disable Migration Manager for Scala
-    // TODO: re-enable once ScalusBlueprintPlugin is published
-    // .enablePlugins(ScalusBlueprintPlugin)
+    .enablePlugins(ScalusBlueprintPlugin)
     .settings(
       PluginDependency,
       scalacOptions ++= commonScalacOptions,
@@ -792,6 +791,8 @@ lazy val scalusCardanoLedgerIt = project
       publish / skip := true,
       Test / fork := true,
       Test / testOptions += Tests.Argument("-oF"),
+      // Forward SCALUS_TEST_ENV to forked test JVM
+      Test / envVars ++= sys.env.get("SCALUS_TEST_ENV").map("SCALUS_TEST_ENV" -> _).toMap,
       libraryDependencies += "com.bloxbean.cardano" % "cardano-client-lib" % cardanoClientLibVersion % "test",
       libraryDependencies += "com.bloxbean.cardano" % "cardano-client-backend-blockfrost" % cardanoClientLibVersion % "test",
       libraryDependencies += "com.bloxbean.cardano" % "yaci" % yaciVersion % "test",

--- a/eject-examples
+++ b/eject-examples
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+#
+# eject-examples — create standalone sbt projects from Scalus examples.
+#
+# Usage:
+#   ./eject-examples --all <target-dir>
+#   ./eject-examples --only <name> [<name> ...] <target-dir>
+#   ./eject-examples --list
+#
+# Each ejected project is a self-contained sbt build that depends on published
+# Scalus artifacts, configures the Scalus compiler plugin, and enables
+# ScalusBlueprintPlugin (so `sbt blueprint` and `sbt deploy` work out of the box).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+EXAMPLES_ROOT="$SCRIPT_DIR/scalus-examples/jvm/src/main/scala/scalus/examples"
+
+# Extract `val scalusStableVersion = "X.Y.Z"` from build.sbt.
+# `|| true` prevents pipefail from masking the "not found" case.
+SCALUS_VERSION="$({ grep -E '^val scalusStableVersion\s*=' "$SCRIPT_DIR/build.sbt" \
+    || true; } | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+if [[ -z "$SCALUS_VERSION" ]]; then
+    echo "error: could not determine scalusStableVersion from build.sbt" >&2
+    exit 1
+fi
+
+# Read sbt version from this repo so ejected projects use the same.
+SBT_VERSION="$({ grep -E '^sbt\.version' "$SCRIPT_DIR/project/build.properties" \
+    || true; } | cut -d= -f2 | tr -d ' ')"
+SBT_VERSION="${SBT_VERSION:-1.12.9}"
+
+SCALA_VERSION="3.3.7"
+
+usage() {
+    cat <<EOF
+Usage:
+  $(basename "$0") [--scalus-version V] --all <target-dir>
+  $(basename "$0") [--scalus-version V] --only <name> [<name> ...] <target-dir>
+  $(basename "$0") --list
+
+Options:
+  --scalus-version Override the Scalus version pinned in the generated project.
+                   Default: \`val scalusStableVersion\` from build.sbt.
+                   Use a locally-published SNAPSHOT (e.g. from \`sbtn publishLocal\`)
+                   when the target version isn't on Maven Central yet.
+  --all            Eject every directory-based example.
+  --only NAMES...  Eject only the named examples (last arg is target dir).
+  --list           Print all available examples and exit.
+
+Each example becomes <target-dir>/<name>/ with its own build.sbt,
+project/plugins.sbt, README.md, and copied sources.
+EOF
+}
+
+list_examples() {
+    find "$EXAMPLES_ROOT" -mindepth 1 -maxdepth 1 -type d \
+        -exec basename {} \; | sort
+}
+
+# ---- generators -------------------------------------------------------------
+
+detect_extra_deps() {
+    local src_dir="$1"
+    local extras=()
+    if grep -rqE '^[[:space:]]*import[[:space:]]+scalus\.bloxbean' "$src_dir" 2>/dev/null; then
+        extras+=( '"org.scalus" %% "scalus-bloxbean-cardano-client-lib" % scalusVersion' )
+    fi
+    if grep -rqE '^[[:space:]]*import[[:space:]]+scalus\.patterns' "$src_dir" 2>/dev/null; then
+        # scalus-design-patterns is JVM-only and not yet on Maven Central;
+        # user must `sbt publishLocal` it.
+        extras+=( '"org.scalus" %% "scalus-design-patterns" % scalusVersion' )
+    fi
+    # Guard empty-array expansion for bash 3.2 under `set -u`.
+    if (( ${#extras[@]} )); then
+        printf '%s\n' "${extras[@]}"
+    fi
+}
+
+gen_build_sbt() {
+    local name="$1" src_dir="$2"
+    local extras
+    extras="$(detect_extra_deps "$src_dir")"
+    local extra_lines=""
+    if [[ -n "$extras" ]]; then
+        while IFS= read -r dep; do
+            extra_lines+=",
+            $dep"
+        done <<< "$extras"
+    fi
+    cat <<EOF
+ThisBuild / scalaVersion := "$SCALA_VERSION"
+ThisBuild / organization := "org.example"
+ThisBuild / version      := "0.1.0-SNAPSHOT"
+
+val scalusVersion = "$SCALUS_VERSION"
+
+lazy val root = (project in file("."))
+    .enablePlugins(ScalusBlueprintPlugin)
+    .settings(
+        name := "$name",
+        scalacOptions ++= Seq("-deprecation", "-feature"),
+        addCompilerPlugin(("org.scalus" %% "scalus-plugin" % scalusVersion).cross(CrossVersion.full)),
+        libraryDependencies ++= Seq(
+            "org.scalus" %% "scalus"                % scalusVersion,
+            "org.scalus" %% "scalus-cardano-ledger" % scalusVersion$extra_lines
+        )
+    )
+EOF
+}
+
+gen_plugins_sbt() {
+    cat <<EOF
+addSbtPlugin("org.scalus" % "scalus-sbt-plugin" % "$SCALUS_VERSION")
+EOF
+}
+
+gen_build_properties() {
+    cat <<EOF
+sbt.version=$SBT_VERSION
+EOF
+}
+
+gen_gitignore() {
+    cat <<'EOF'
+target/
+project/target/
+project/project/
+.bsp/
+.bloop/
+.metals/
+.idea/
+.vscode/
+EOF
+}
+
+gen_readme() {
+    local name="$1"
+    cat <<EOF
+# $name
+
+Standalone Scalus example, ejected from
+[scalus3/scalus](https://github.com/scalus3/scalus).
+
+## Build
+
+\`\`\`sh
+sbt compile
+\`\`\`
+
+## Generate a CIP-57 blueprint
+
+\`\`\`sh
+sbt blueprint
+\`\`\`
+
+Blueprint JSON is written to
+\`target/scala-$SCALA_VERSION/classes/META-INF/scalus/blueprints/<Contract>.json\`.
+
+## Deploy as a reference script
+
+Requires a Blockfrost project id and a funded wallet mnemonic on the chosen network.
+
+\`\`\`sh
+sbt "deploy <ContractName> --network preview \\
+    --blockfrost-key <project-id> \\
+    --mnemonic '<24 words>'"
+\`\`\`
+
+Or via environment variables:
+
+\`\`\`sh
+export CARDANO_NETWORK=preview
+export BLOCKFROST_API_KEY=<project-id>
+export CARDANO_MNEMONIC='<24 words>'
+sbt "deploy <ContractName>"
+\`\`\`
+
+The contract is deployed as a reference script UTxO at the sender's own base
+address; the transaction hash is printed on success.
+
+## Pinned versions
+
+- Scalus: \`$SCALUS_VERSION\`
+- Scala:  \`$SCALA_VERSION\`
+- sbt:    \`$SBT_VERSION\`
+EOF
+}
+
+# ---- core -------------------------------------------------------------------
+
+eject_one() {
+    local name="$1" target_root="$2"
+    local src_dir="$EXAMPLES_ROOT/$name"
+    if [[ ! -d "$src_dir" ]]; then
+        echo "error: example '$name' not found at $src_dir" >&2
+        return 1
+    fi
+
+    local project_dir="$target_root/$name"
+    if [[ -e "$project_dir" ]]; then
+        echo "error: $project_dir already exists, refusing to overwrite" >&2
+        return 1
+    fi
+
+    mkdir -p "$project_dir/project"
+    mkdir -p "$project_dir/src/main/scala/scalus/examples/$name"
+
+    cp -R "$src_dir"/. "$project_dir/src/main/scala/scalus/examples/$name"/
+
+    gen_build_sbt "$name" "$src_dir" > "$project_dir/build.sbt"
+    gen_plugins_sbt               > "$project_dir/project/plugins.sbt"
+    gen_build_properties          > "$project_dir/project/build.properties"
+    gen_gitignore                 > "$project_dir/.gitignore"
+    gen_readme "$name"            > "$project_dir/README.md"
+
+    echo "  ejected $name -> $project_dir"
+}
+
+main() {
+    if [[ $# -eq 0 ]]; then usage; exit 1; fi
+
+    # Parse flags in any order; collect positional args.
+    local mode=""
+    local positional=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)    usage; exit 0 ;;
+            --list)       mode="list"; shift ;;
+            --all)        mode="all";  shift ;;
+            --only)       mode="only"; shift ;;
+            --scalus-version)
+                if [[ $# -lt 2 ]]; then
+                    echo "error: --scalus-version requires a value" >&2; exit 1
+                fi
+                SCALUS_VERSION="$2"; shift 2 ;;
+            --*)
+                echo "error: unknown option '$1'" >&2; usage; exit 1 ;;
+            *)
+                positional+=( "$1" ); shift ;;
+        esac
+    done
+
+    if [[ -d "$EXAMPLES_ROOT" ]]; then :; else
+        echo "error: examples root not found: $EXAMPLES_ROOT" >&2
+        exit 1
+    fi
+
+    local failures=0
+    case "$mode" in
+        list)
+            list_examples ;;
+        all)
+            if [[ ${#positional[@]} -ne 1 ]]; then
+                echo "error: --all takes exactly one argument: <target-dir>" >&2
+                exit 1
+            fi
+            local target="${positional[0]}"
+            mkdir -p "$target"
+            echo "ejecting all examples to $target (scalus $SCALUS_VERSION)"
+            while IFS= read -r name; do
+                eject_one "$name" "$target" || failures=$((failures + 1))
+            done < <(list_examples)
+            ;;
+        only)
+            if [[ ${#positional[@]} -lt 2 ]]; then
+                echo "error: --only requires at least one example name and a target dir" >&2
+                exit 1
+            fi
+            local target="${positional[${#positional[@]}-1]}"
+            local names=( "${positional[@]:0:${#positional[@]}-1}" )
+            mkdir -p "$target"
+            echo "ejecting ${#names[@]} example(s) to $target (scalus $SCALUS_VERSION)"
+            for name in "${names[@]}"; do
+                eject_one "$name" "$target" || failures=$((failures + 1))
+            done
+            ;;
+        "")
+            usage; exit 1 ;;
+    esac
+
+    if [[ $failures -gt 0 ]]; then
+        echo "done with $failures failure(s); see messages above" >&2
+    fi
+}
+
+main "$@"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 // buildinfo
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
+
+Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "scalus-sbt-plugin" / "src" / "main" / "scala"

--- a/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/deploy/Deployer.scala
+++ b/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/deploy/Deployer.scala
@@ -1,6 +1,5 @@
 package scalus.cardano.deploy
 
-import scalus.cardano.address.Address
 import scalus.cardano.blueprint.Contract
 import scalus.cardano.ledger.*
 import scalus.cardano.ledger.utils.MinCoinSizedTransactionOutput
@@ -30,9 +29,8 @@ object Deployer {
       * @param blockfrostApiKey
       *   Blockfrost API key
       * @param mnemonic
-      *   BIP-39 mnemonic for signing
-      * @param targetAddress
-      *   Bech32 address where the reference script UTXO will be created
+      *   BIP-39 mnemonic for signing; the reference-script UTXO is created at the sender's own base
+      *   address derived from this mnemonic
       * @return
       *   transaction hash hex string
       */
@@ -40,8 +38,7 @@ object Deployer {
         contractClassName: String,
         network: String,
         blockfrostApiKey: String,
-        mnemonic: String,
-        targetAddress: String
+        mnemonic: String
     ): String = {
         val cls = Class.forName(contractClassName)
         val contract = cls.getField("MODULE$").get(null).asInstanceOf[Contract]
@@ -75,14 +72,14 @@ object Deployer {
         val account = HdAccount.fromMnemonic(mnemonic)
         val senderAddress = account.baseAddress(provider.network)
 
-        val address = Address.fromBech32(targetAddress)
         val scriptRef = Some(ScriptRef(script))
-        val draftOutput = TransactionOutput.Babbage(address, Value.lovelace(0), None, scriptRef)
+        val draftOutput =
+            TransactionOutput.Babbage(senderAddress, Value.lovelace(0), None, scriptRef)
         val minCoin = MinCoinSizedTransactionOutput.ensureMinAda(
           Sized(draftOutput),
           provider.cardanoInfo.protocolParams
         )
-        val output = TransactionOutput.Babbage(address, Value(minCoin), None, scriptRef)
+        val output = TransactionOutput.Babbage(senderAddress, Value(minCoin), None, scriptRef)
 
         val tx = TxBuilder(provider.cardanoInfo)
             .output(output)
@@ -95,4 +92,5 @@ object Deployer {
             case Right(txHash) => txHash.toHex
             case Left(error)   => throw RuntimeException(s"Deploy failed: ${error.message}")
     }
+
 }

--- a/scalus-design-patterns/README.md
+++ b/scalus-design-patterns/README.md
@@ -435,7 +435,7 @@ object FactoryExample extends Validator {
 }
 ```
 
-See `scalus.examples.FactoryExample` for the complete implementation.
+See `scalus.examples.factory.FactoryExample` for the complete implementation.
 
 ## Indexing Patterns
 

--- a/scalus-examples/jvm/src/main/scala/scalus/examples/factory/Factory.scala
+++ b/scalus-examples/jvm/src/main/scala/scalus/examples/factory/Factory.scala
@@ -1,4 +1,4 @@
-package scalus.patterns
+package scalus.examples.factory
 
 import scalus.*
 import scalus.uplc.builtin.Builtins

--- a/scalus-examples/jvm/src/main/scala/scalus/examples/factory/FactoryExample.scala
+++ b/scalus-examples/jvm/src/main/scala/scalus/examples/factory/FactoryExample.scala
@@ -1,10 +1,10 @@
-package scalus.examples
+package scalus.examples.factory
 
 import scalus.*
 import scalus.uplc.builtin.Data
 import scalus.compiler.Options
+import scalus.cardano.blueprint.{Blueprint, Contract}
 import scalus.cardano.onchain.plutus.v3.*
-import scalus.patterns.{Factory, FactoryAction, ProductDatum}
 import scalus.cardano.onchain.plutus.prelude.*
 import scalus.cardano.onchain.plutus.v3.Validator
 import scalus.uplc.PlutusV3
@@ -74,9 +74,17 @@ object FactoryExample extends Validator {
     }
 }
 
-private object FactoryCompilation {
-    private given compilerOptions: Options = Options.release
-    lazy val contract = PlutusV3.compile(FactoryExample.validate)
+object FactoryContract extends Contract {
+    private given Options = Options.release
+    lazy val compiled = PlutusV3.compile(FactoryExample.validate)
+    lazy val blueprint = Blueprint.plutusV3[ProductDatum, FactoryAction](
+      title = "Factory",
+      description =
+          "Factory pattern: a combined minting + spending validator. " +
+              "Create mints a one-shot product NFT via a seed UTxO and locks a product UTxO " +
+              "at the script address. Destroy / spend burn the NFT with the creator's signature.",
+      version = "1.0.0",
+      license = Some("Apache-2.0"),
+      compiled = compiled
+    )
 }
-
-lazy val FactoryExampleContract = FactoryCompilation.contract

--- a/scalus-examples/jvm/src/main/scala/scalus/examples/factory/FactoryExample.scala
+++ b/scalus-examples/jvm/src/main/scala/scalus/examples/factory/FactoryExample.scala
@@ -79,10 +79,9 @@ object FactoryContract extends Contract {
     lazy val compiled = PlutusV3.compile(FactoryExample.validate)
     lazy val blueprint = Blueprint.plutusV3[ProductDatum, FactoryAction](
       title = "Factory",
-      description =
-          "Factory pattern: a combined minting + spending validator. " +
-              "Create mints a one-shot product NFT via a seed UTxO and locks a product UTxO " +
-              "at the script address. Destroy / spend burn the NFT with the creator's signature.",
+      description = "Factory pattern: a combined minting + spending validator. " +
+          "Create mints a one-shot product NFT via a seed UTxO and locks a product UTxO " +
+          "at the script address. Destroy / spend burn the NFT with the creator's signature.",
       version = "1.0.0",
       license = Some("Apache-2.0"),
       compiled = compiled

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/factory/FactoryTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/factory/FactoryTest.scala
@@ -1,4 +1,4 @@
-package scalus.patterns
+package scalus.examples.factory
 
 import org.scalatest.funsuite.AnyFunSuite
 import scalus.*

--- a/scalus-sbt-plugin/src/main/scala/scalus/sbt/ScalusBlueprintPlugin.scala
+++ b/scalus-sbt-plugin/src/main/scala/scalus/sbt/ScalusBlueprintPlugin.scala
@@ -9,8 +9,8 @@ import sbt.complete.DefaultParsers.*
   *
   * - `sbt blueprint` writes each contract's blueprint to
   *   `META-INF/scalus/blueprints/<ContractName>.json` in the classes directory.
-  * - `sbt "deploy <ContractName> --network preview --blockfrost-key <key> --mnemonic '<words>' --address <addr>"`
-  *   deploys a validator as a reference script UTXO.
+  * - `sbt "deploy <ContractName> --network preview --blockfrost-key <key> --mnemonic '<words>'"`
+  *   deploys a validator as a reference script UTXO at the sender's own base address.
   *
   * Environment variables can substitute CLI flags:
   *   - `CARDANO_NETWORK` for `--network` (default: "preview")
@@ -54,7 +54,7 @@ object ScalusBlueprintPlugin extends AutoPlugin {
         val log = streams.value.log
         val args = spaceDelimited("<args>").parsed
 
-        val (contractName, network, blockfrostKey, mnemonicStr, address) = parseDeployArgs(args)
+        val (contractName, network, blockfrostKey, mnemonicStr) = parseDeployArgs(args)
 
         val classNames = readManifestClassNames(classesDir)
         if (classNames.isEmpty) sys.error("No Contract implementations found. Run `compile` first.")
@@ -84,11 +84,10 @@ object ScalusBlueprintPlugin extends AutoPlugin {
                 classOf[String],
                 classOf[String],
                 classOf[String],
-                classOf[String],
                 classOf[String]
             )
             val txHash = deployMethod
-                .invoke(null, className, network, blockfrostKey, mnemonicStr, address)
+                .invoke(null, className, network, blockfrostKey, mnemonicStr)
                 .asInstanceOf[String]
             log.info(s"Deployed successfully! Transaction hash: $txHash")
         } catch {
@@ -174,12 +173,11 @@ object ScalusBlueprintPlugin extends AutoPlugin {
             )
     }
 
-    private def parseDeployArgs(args: Seq[String]): (String, String, String, String, String) = {
+    private def parseDeployArgs(args: Seq[String]): (String, String, String, String) = {
         var contractName: Option[String] = None
         var network: Option[String] = None
         var blockfrostKey: Option[String] = None
         var mnemonic: Option[String] = None
-        var address: Option[String] = None
 
         val iter = args.iterator
         while (iter.hasNext) {
@@ -193,9 +191,6 @@ object ScalusBlueprintPlugin extends AutoPlugin {
                 case "--mnemonic" =>
                     if (!iter.hasNext) sys.error("--mnemonic requires a value")
                     mnemonic = Some(iter.next())
-                case "--address" =>
-                    if (!iter.hasNext) sys.error("--address requires a value")
-                    address = Some(iter.next())
                 case name if contractName.isEmpty =>
                     contractName = Some(name)
                 case other =>
@@ -213,8 +208,7 @@ object ScalusBlueprintPlugin extends AutoPlugin {
               .getOrElse(sys.error("--blockfrost-key or BLOCKFROST_API_KEY env var is required")),
           mnemonic
               .orElse(sys.env.get("CARDANO_MNEMONIC"))
-              .getOrElse(sys.error("--mnemonic or CARDANO_MNEMONIC env var is required")),
-          address.getOrElse(sys.error("--address is required"))
+              .getOrElse(sys.error("--mnemonic or CARDANO_MNEMONIC env var is required"))
         )
     }
 }


### PR DESCRIPTION
The Scalus sbt plugin now sits in the scalus repo, enabled and usable.

The ejector script is a utility that allows to take the saclus-examples module, and produce one or several standalone SBT projects (1 per validator) from it. The produced projects have the validator code and the scalus plugin, allowing us to produce contained yet functional example projects.