### PR TITLE
fix: don't leak intrinsic binding's internal TypeVars across dispatches

### DIFF
--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -898,7 +898,27 @@ object IntrinsicResolver {
         // still references them.
         val bindingInternalTvs =
             scala.collection.mutable.Set.empty[SIRType.TypeVar]
-        SIRType.mapTypeVars(binding.tp, tv => { bindingInternalTvs += tv; tv })
+        // Non-allocating walk to collect TypeVars from `binding.tp`. We only need
+        // identity, not a rebuilt type tree, so avoid `SIRType.mapTypeVars` which
+        // would allocate fresh `TypeProxy` / structural nodes per dispatch.
+        val seenProxies = new java.util.IdentityHashMap[SIRType.TypeProxy, Boolean]()
+        def collectTvs(t: SIRType): Unit = t match
+            case tv: SIRType.TypeVar => bindingInternalTvs += tv
+            case SIRType.TypeLambda(ps, body) =>
+                ps.foreach(bindingInternalTvs += _)
+                collectTvs(body)
+            case SIRType.Fun(in, out) => collectTvs(in); collectTvs(out)
+            case SIRType.CaseClass(_, args, parent) =>
+                args.foreach(collectTvs)
+                parent.foreach(collectTvs)
+            case SIRType.SumCaseClass(_, args) => args.foreach(collectTvs)
+            case SIRType.Annotated(t1, _)      => collectTvs(t1)
+            case SIRType.TypeProxy(ref) =>
+                if ref != null && !seenProxies.containsKey(t) then
+                    seenProxies.put(t.asInstanceOf[SIRType.TypeProxy], true)
+                    collectTvs(ref)
+            case _ => ()
+        collectTvs(binding.tp)
         val afterCrossFilled = filledFromUnify.foldLeft(afterOutput) { case (acc, (tv, t)) =>
             if !acc.contains(tv) then acc + (tv -> t)
             else if bindingInternalTvs.contains(tv) then acc + (tv -> t) // overwrite stale

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -335,54 +335,8 @@ object IntrinsicResolver {
                                         Lowering.lowerSIR(substituted, Some(loweringAppType))
                                     finally
                                         lctx.inUplcConstrListScope = savedScope
-                                        // Merge filledTypes back to outer scope, but EXCLUDE
-                                        // entries introduced by THIS dispatch that bind the
-                                        // binding's own internal TypeVars. The compiled
-                                        // intrinsic binding is shared across dispatches, so
-                                        // its internal `[A, B]` TypeVars (e.g. `B#523` for
-                                        // map's binding) keep the same optIds at every call
-                                        // site. If we let those bindings leak into the outer
-                                        // scope, the next dispatch of the same binding would
-                                        // see a stale `B#523 → <prev appType element>` in
-                                        // `filledTypes`, and the unify-against-callSite at
-                                        // `bindIntrinsicListResolverElementTypeVars1` would
-                                        // be unable to overwrite it (line 905's
-                                        // `if acc.contains(tv) then acc` keeps the carryover).
-                                        // The result is the abstract `List[B]` static throw
-                                        // at `uplcConstrToBuiltinList: cannot convert with
-                                        // TypeVar element B`.
-                                        //
-                                        // Walk `binding.tp` (signature) for the binding's
-                                        // internal TypeVar identities. NOTE: deliberately
-                                        // NOT walking `binding.value` — substituteSelf
-                                        // splices argCache-bound call-site TypeVars into
-                                        // the body, and walking the body would harvest
-                                        // those legitimate call-site TVs too, then strip
-                                        // their bindings from the outer scope. Keep this
-                                        // walk signature-only; if a future binding ever
-                                        // declares a TypeVar in the body that isn't in the
-                                        // signature, fix it at that binding's declaration
-                                        // rather than widening this filter.
-                                        // Restrict the filter to entries NEWLY introduced
-                                        // during this dispatch — any pre-existing call-site
-                                        // binding under a colliding `(name, optId)` key is
-                                        // preserved (defensive against TypeVar id aliasing).
-                                        val bindingInternalTvs =
-                                            scala.collection.mutable.Set
-                                                .empty[SIRType.TypeVar]
-                                        SIRType.mapTypeVars(
-                                          binding.tp,
-                                          tv => { bindingInternalTvs += tv; tv }
-                                        )
-                                        val savedKeys = savedFilledTypes.keySet
-                                        val newBindings =
-                                            lctx.typeUnifyEnv.filledTypes.view
-                                                .filterKeys(k =>
-                                                    savedKeys.contains(k)
-                                                        || !bindingInternalTvs.contains(k)
-                                                )
-                                                .toMap
-                                        val merged = savedFilledTypes ++ newBindings
+                                        val merged =
+                                            savedFilledTypes ++ lctx.typeUnifyEnv.filledTypes
                                         lctx.typeUnifyEnv =
                                             lctx.typeUnifyEnv.copy(filledTypes = merged)
                                         lctx.typeVarReprEnv = savedReprEnv
@@ -929,10 +883,26 @@ object IntrinsicResolver {
         val filledFromUnify: Map[SIRType.TypeVar, SIRType] = unifyResult match
             case SIRUnify.UnificationSuccess(env, _) => env.filledTypes
             case _                                   => Map.empty
-        // First, propagate filledFromUnify (handles the case where one side was pre-filled
-        // — not expected here but defensive).
+        // Propagate filledFromUnify. The compiled intrinsic binding is shared across
+        // dispatches, so its internal TypeVars (e.g. `B#523` for `List$.map`'s `[A, B]`)
+        // keep the same optIds at every call site. A previous dispatch leaves stale
+        // bindings for those TypeVars in `lctx.typeUnifyEnv.filledTypes`; the fresh
+        // unify against this call site's `callSiteTpStripped` rebinds them to the
+        // current site's appType element. We must let the fresh bindings OVERWRITE
+        // the stale carryover for binding-internal TypeVars — otherwise the next
+        // dispatch of the same binding would see e.g. `B#523 → <prev appType element>`
+        // and propagate it through downstream lowering, surfacing as the residual
+        // `LoweringException: cannot convert with TypeVar element B` heisenbug.
+        // Pre-existing call-site TypeVars (not in the binding's signature) keep
+        // their existing bindings — that's correct, the call site's outer code
+        // still references them.
+        val bindingInternalTvs =
+            scala.collection.mutable.Set.empty[SIRType.TypeVar]
+        SIRType.mapTypeVars(binding.tp, tv => { bindingInternalTvs += tv; tv })
         val afterCrossFilled = filledFromUnify.foldLeft(afterOutput) { case (acc, (tv, t)) =>
-            if acc.contains(tv) then acc else acc + (tv -> t)
+            if !acc.contains(tv) then acc + (tv -> t)
+            else if bindingInternalTvs.contains(tv) then acc + (tv -> t) // overwrite stale
+            else acc                                                      // keep call-site
         }
         // Then walk eqClasses: for each TypeVar not yet bound, if any of its equivalents
         // IS bound in afterCrossFilled, inherit that concrete type.

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -902,7 +902,7 @@ object IntrinsicResolver {
         val afterCrossFilled = filledFromUnify.foldLeft(afterOutput) { case (acc, (tv, t)) =>
             if !acc.contains(tv) then acc + (tv -> t)
             else if bindingInternalTvs.contains(tv) then acc + (tv -> t) // overwrite stale
-            else acc                                                      // keep call-site
+            else acc // keep call-site
         }
         // Then walk eqClasses: for each TypeVar not yet bound, if any of its equivalents
         // IS bound in afterCrossFilled, inherit that concrete type.

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -335,8 +335,32 @@ object IntrinsicResolver {
                                         Lowering.lowerSIR(substituted, Some(loweringAppType))
                                     finally
                                         lctx.inUplcConstrListScope = savedScope
-                                        val merged =
-                                            savedFilledTypes ++ lctx.typeUnifyEnv.filledTypes
+                                        // Merge filledTypes back to outer scope, but EXCLUDE
+                                        // the binding's own internal TypeVars. The compiled
+                                        // intrinsic binding is shared across dispatches, so
+                                        // its internal `[A, B]` TypeVars (e.g. `B#523` for
+                                        // map's binding) keep the same optIds at every call
+                                        // site. If we let those bindings leak into the outer
+                                        // scope, the next dispatch of the same binding would
+                                        // see a stale `B#523 → <prev appType element>` in
+                                        // `filledTypes`, and the unify-against-callSite at
+                                        // `bindIntrinsicListResolverElementTypeVars1` would
+                                        // be unable to overwrite it (line 905's
+                                        // `if acc.contains(tv) then acc` keeps the carryover).
+                                        // The result is the abstract `List[B]` static throw
+                                        // at `uplcConstrToBuiltinList: cannot convert with
+                                        // TypeVar element B`. Filter the binding's TypeVars
+                                        // out of the merge.
+                                        val bindingInternalTvs =
+                                            scala.collection.mutable.Set
+                                                .empty[SIRType.TypeVar]
+                                        SIRType.mapTypeVars(
+                                          binding.tp,
+                                          tv => { bindingInternalTvs += tv; tv }
+                                        )
+                                        val newBindings =
+                                            lctx.typeUnifyEnv.filledTypes -- bindingInternalTvs
+                                        val merged = savedFilledTypes ++ newBindings
                                         lctx.typeUnifyEnv =
                                             lctx.typeUnifyEnv.copy(filledTypes = merged)
                                         lctx.typeVarReprEnv = savedReprEnv

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -336,7 +336,8 @@ object IntrinsicResolver {
                                     finally
                                         lctx.inUplcConstrListScope = savedScope
                                         // Merge filledTypes back to outer scope, but EXCLUDE
-                                        // the binding's own internal TypeVars. The compiled
+                                        // entries introduced by THIS dispatch that bind the
+                                        // binding's own internal TypeVars. The compiled
                                         // intrinsic binding is shared across dispatches, so
                                         // its internal `[A, B]` TypeVars (e.g. `B#523` for
                                         // map's binding) keep the same optIds at every call
@@ -349,8 +350,23 @@ object IntrinsicResolver {
                                         // `if acc.contains(tv) then acc` keeps the carryover).
                                         // The result is the abstract `List[B]` static throw
                                         // at `uplcConstrToBuiltinList: cannot convert with
-                                        // TypeVar element B`. Filter the binding's TypeVars
-                                        // out of the merge.
+                                        // TypeVar element B`.
+                                        //
+                                        // Walk `binding.tp` (signature) for the binding's
+                                        // internal TypeVar identities. NOTE: deliberately
+                                        // NOT walking `binding.value` — substituteSelf
+                                        // splices argCache-bound call-site TypeVars into
+                                        // the body, and walking the body would harvest
+                                        // those legitimate call-site TVs too, then strip
+                                        // their bindings from the outer scope. Keep this
+                                        // walk signature-only; if a future binding ever
+                                        // declares a TypeVar in the body that isn't in the
+                                        // signature, fix it at that binding's declaration
+                                        // rather than widening this filter.
+                                        // Restrict the filter to entries NEWLY introduced
+                                        // during this dispatch — any pre-existing call-site
+                                        // binding under a colliding `(name, optId)` key is
+                                        // preserved (defensive against TypeVar id aliasing).
                                         val bindingInternalTvs =
                                             scala.collection.mutable.Set
                                                 .empty[SIRType.TypeVar]
@@ -358,8 +374,14 @@ object IntrinsicResolver {
                                           binding.tp,
                                           tv => { bindingInternalTvs += tv; tv }
                                         )
+                                        val savedKeys = savedFilledTypes.keySet
                                         val newBindings =
-                                            lctx.typeUnifyEnv.filledTypes -- bindingInternalTvs
+                                            lctx.typeUnifyEnv.filledTypes.view
+                                                .filterKeys(k =>
+                                                    savedKeys.contains(k)
+                                                        || !bindingInternalTvs.contains(k)
+                                                )
+                                                .toMap
                                         val merged = savedFilledTypes ++ newBindings
                                         lctx.typeUnifyEnv =
                                             lctx.typeUnifyEnv.copy(filledTypes = merged)


### PR DESCRIPTION
## Summary

Closes the residual `LoweringException: cannot convert with TypeVar element B`
heisenbug at `KnightsTest.scala:474:20-475:94` that survived PR #254.

## Root cause

The compiled intrinsic binding for `List$.map` (and friends — `filter`,
`filterMap`, `flatMap`, `quicksort`) is shared across all call sites. Its
internal `[A, B]` TypeVars keep the same `optId` (e.g. `B#523`) at every
dispatch.

`IntrinsicResolver.tryResolveFull`'s `finally` block merged the full
post-dispatch `lctx.typeUnifyEnv.filledTypes` back into the saved outer
state. Once the FIRST dispatch bound `B#523 → SolutionEntry` (from the
call site's appType), the merge wrote that mapping into the outer scope.
The NEXT dispatch of the same `map` binding then started with
`B#523 → SolutionEntry` already in `filledTypes`, and
`bindIntrinsicListResolverElementTypeVars1` could not overwrite it — line
905's `if acc.contains(tv) then acc` favours the carryover.

The diagnostic trace confirms the leak: every map dispatch in a Knights
compile shows `B#523 → SolutionEntry` already present at dispatch entry,
even at sites whose appType element should be `ChessSet`.

## Fix

Collect the binding's internal TypeVars from `binding.tp` and exclude
**newly-introduced** entries that bind those TypeVars from the merge-back.
Pre-existing call-site bindings (in `savedFilledTypes`) are preserved.
Body-internal walk is intentionally omitted because `substituteSelf`
splices argCache-bound call-site TypeVars into the body.

## Verification

- `scalusJVM/test`: 3184/3184 (no regression)
- `Knights+KnightsTestMinimal`: 26/26 over 3 deterministic runs (master at
  the same point flapped 25/26 with the residual heisenbug)
- `scalusExamplesJVM/test` (full): 432/432
- Budget snapshots identical to master (correctness fix only)
- `[warnListConversions]` event count delta: 377 → 376 (~unchanged)