### PR TITLE
fix: resolve abstract TypeVar element in uplcConstrToBuiltinList

### DIFF
--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/ScalusRuntime.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/ScalusRuntime.scala
@@ -777,9 +777,19 @@ object ScalusRuntime {
               s"[warnListConversions] SumUplcConstr→SumBuiltinList at ${pos.show}: ${input.sirType.show}"
             )
         val listType = input.sirType
-        val elemType = SumCaseClassRepresentation.SumBuiltinList
+        val rawElemType = SumCaseClassRepresentation.SumBuiltinList
             .retrieveListElementType(listType)
             .getOrElse(SIRType.Data.tp)
+        // If the input's static type carries an abstract `TypeVar` element (e.g.
+        // `List[B]` from a generic intrinsic-binding that hasn't been alpha-renamed
+        // at the call site), try to resolve it from `lctx.typeUnifyEnv.filledTypes`
+        // before bailing. The intrinsic dispatcher's
+        // `bindIntrinsicListResolverElementTypeVars1` will have bound the TypeVar
+        // to the concrete element type during the dispatch — using that here lets
+        // downstream Data-encoding emit against the right concrete type.
+        val elemType = rawElemType match
+            case tv: SIRType.TypeVar => lctx.resolveTypeVarIfNeeded(tv)
+            case other               => other
         val outElemRepr = outListRepr.elementRepr
         // Resolve target element repr: TypeVarRepresentation(Fixed) → defaultTypeVarRepresentation
         val resolvedOutElemRepr = outElemRepr match


### PR DESCRIPTION
## Summary

Closes the residual `LoweringException: cannot convert with TypeVar element B`
heisenbug at `runKnights depth=50/100 size=4` in KnightsTestMinimal that
survived PR #258.

## Root cause

PR #258 fixed the carryover leak at
`bindIntrinsicListResolverElementTypeVars1` (rebind binding-internal
TypeVars at the unify-merge). That closed the leak between sibling
intrinsic dispatches, but `uplcConstrToBuiltinList` itself was still
throwing whenever its `input.sirType` had a TypeVar element — even when
the binding for that TypeVar was already in `lctx.typeUnifyEnv.filledTypes`
(because the dispatcher had set it correctly for THIS dispatch).

The throw was too eager: `retrieveListElementType(listType)` returns the
raw element type without consulting `typeUnifyEnv`. For `List[B]` where
`B → SolutionEntry` is in the unify env, the throw fired on the abstract
`B` even though the concrete type was reachable.

## Fix

At the top of `uplcConstrToBuiltinList`, when `retrieveListElementType`
returns a `TypeVar`, run `lctx.resolveTypeVarIfNeeded` first. If the
unify env has a concrete binding, use it. The throw is preserved as a
fallback for genuinely unresolved cases (better diagnostic than silent
fallback to Data).

## Verification

- `scalusJVM/test`: 3184/3184 (no regression)
- `Knights+KnightsTestMinimal`: 26/26 over 4 deterministic runs (master at
  the same point flapped the residual)
- `scalusExamplesJVM/test` (full): 432/432