### PR TITLE
refactor: replace stampTransparent with @UplcRepr annotations on native list ops

### DIFF
--- a/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/IntrinsicsNativeList.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/IntrinsicsNativeList.scala
@@ -2,6 +2,9 @@ package scalus.compiler.intrinsics
 
 import scalus.Compile
 import scalus.cardano.onchain.plutus.prelude.{List, Option}
+import scalus.compiler.UplcRepr
+import scalus.compiler.UplcRepresentation.TypeVar
+import scalus.compiler.UplcRepresentation.TypeVarKind.Transparent
 import scalus.compiler.intrinsics.IntrinsicHelpers.*
 import scalus.uplc.builtin.BuiltinList
 import scalus.uplc.builtin.Builtins.*
@@ -11,40 +14,60 @@ import scalus.compiler.intrinsics.IntrinsicHelpers.toDefaultTypeVarRepr
   *
   * The IntrinsicResolver dispatches to these when the list has native element representation
   * (SumBuiltinList with !isPackedData element repr). Each method delegates to NativeListOperations
-  * which has Transparent TypeVars and the actual implementations.
+  * which has the actual implementations.
+  *
+  * Type parameters carry `@UplcRepr(TypeVar(Transparent))` so element bytes flow through without
+  * Data wrapping (matching the historical `stampTransparent` post-load semantics this annotation
+  * replaces). `find` is unannotated — see NativeListOperations.find for the rationale.
   *
   * Simple methods (isEmpty, head, tail) are implemented inline since they're single builtins.
   */
 @Compile
 object IntrinsicsNativeList {
 
-    def isEmpty[A](self: List[A]): Boolean =
+    def isEmpty[@UplcRepr(TypeVar(Transparent)) A](self: List[A]): Boolean =
         nullList(typeProxy[BuiltinList[A]](self))
 
-    def head[A](self: List[A]): A =
+    def head[@UplcRepr(TypeVar(Transparent)) A](self: List[A]): A =
         headList(typeProxy[BuiltinList[A]](self))
 
-    def tail[A](self: List[A]): List[A] =
+    def tail[@UplcRepr(TypeVar(Transparent)) A](self: List[A]): List[A] =
         typeProxy[List[A]](
           tailList(typeProxy[BuiltinList[A]](self))
         )
 
-    def map[A, B](self: List[A], mapper: A => B): List[B] =
+    def map[
+        @UplcRepr(TypeVar(Transparent)) A,
+        @UplcRepr(TypeVar(Transparent)) B
+    ](self: List[A], mapper: A => B): List[B] =
         NativeListOperations.map(self, mapper)
 
-    def filter[A](self: List[A], predicate: A => Boolean): List[A] =
+    def filter[@UplcRepr(TypeVar(Transparent)) A](
+        self: List[A],
+        predicate: A => Boolean
+    ): List[A] =
         NativeListOperations.filter(self, predicate)
 
-    def foldLeft[A, B](self: List[A], init: B, combiner: (B, A) => B): B =
+    def foldLeft[
+        @UplcRepr(TypeVar(Transparent)) A,
+        @UplcRepr(TypeVar(Transparent)) B
+    ](self: List[A], init: B, combiner: (B, A) => B): B =
         NativeListOperations.foldLeft(self, init, combiner)
 
-    def foldRight[A, B](self: List[A], init: B, combiner: (A, B) => B): B =
+    def foldRight[
+        @UplcRepr(TypeVar(Transparent)) A,
+        @UplcRepr(TypeVar(Transparent)) B
+    ](self: List[A], init: B, combiner: (A, B) => B): B =
         NativeListOperations.foldRight(self, init, combiner)
 
     def find[A](self: List[A], predicate: A => Boolean): Option[A] =
         NativeListOperations.find(self, predicate)
 
-    def contains[A](self: List[A], elem: A, eq: (A, A) => Boolean): Boolean =
+    def contains[@UplcRepr(TypeVar(Transparent)) A](
+        self: List[A],
+        elem: A,
+        eq: (A, A) => Boolean
+    ): Boolean =
         NativeListOperations.contains(
           self,
           elem,

--- a/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/ListIntrinsics.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/ListIntrinsics.scala
@@ -116,9 +116,27 @@ object NativeListReprRules {
     /** foldRight: same as foldLeft */
     val foldRightRule: ReprRule = foldLeftRule
 
-    /** find: List[A] → Option[A] */
-    val findRule: ReprRule = (outTp, _, lctx) =>
-        lctx.typeGenerator(outTp).defaultRepresentation(outTp)(using lctx)
+    /** find: List[A] → (A → Boolean) → Option[A]. For non-PackedData (native-element) sources,
+      * declare `SumUplcConstr Option` so callers stay in native flow; otherwise fall back to the
+      * type's default. The dispatcher converts at the boundary (one element max).
+      */
+    val findRule: ReprRule = (outTp, inRepr, lctx) =>
+        def optionRepr(optTp: SIRType): LoweredValueRepresentation =
+            inRepr match
+                case SumCaseClassRepresentation.SumBuiltinList(elemRepr)
+                    if !elemRepr.isPackedData =>
+                    typegens.SumUplcConstrSirTypeGenerator.buildSumUplcConstr(optTp)(using lctx)
+                case _ =>
+                    lctx.typeGenerator(optTp).defaultRepresentation(optTp)(using lctx)
+        outTp match
+            case SIRType.Fun(argTp, retTp) =>
+                val predicateRepr =
+                    lctx.typeGenerator(argTp).defaultRepresentation(argTp)(using lctx)
+                LambdaRepresentation(
+                  outTp,
+                  InOutRepresentationPair(predicateRepr, optionRepr(retTp))
+                )
+            case _ => optionRepr(outTp)
 
     /** contains: List[A] → A → Eq[A] → Boolean */
     val containsRule: ReprRule = (outTp, _, lctx) =>

--- a/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/NativeListOperations.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/intrinsics/NativeListOperations.scala
@@ -2,14 +2,22 @@ package scalus.compiler.intrinsics
 
 import scalus.Compile
 import scalus.cardano.onchain.plutus.prelude.{List, Option}
+import scalus.compiler.UplcRepr
+import scalus.compiler.UplcRepresentation.TypeVar
+import scalus.compiler.UplcRepresentation.TypeVarKind.Unwrapped
 import scalus.compiler.intrinsics.IntrinsicHelpers.*
 import scalus.uplc.builtin.BuiltinList
 import scalus.uplc.builtin.Builtins.*
 
-/** Native list operations — implementations with Transparent TypeVars.
+/** Native list operations — implementations with Unwrapped TypeVars.
   *
-  * TypeVars are post-processed to Transparent after module loading, so headList/mkCons/nullList
-  * operate on native UPLC values without Data wrapping.
+  * Each generic type parameter carries `@UplcRepr(TypeVar(Unwrapped))` so element bytes flow
+  * through in their stable default representation. `find` is intentionally NOT annotated — its
+  * `Option.Some` / `Option.None` if-then-else body exposes a lowering issue (Option.None doesn't
+  * propagate the target's annotated type-args when constructed under a `@UplcRepr(UplcConstr)`
+  * parent). Without the annotation, the Fixed-default lowering still works (this matched the
+  * historical behaviour, since the legacy `IntrinsicResolver.stampTransparent` call for this
+  * support module was a no-op due to a string-mismatch typo).
   *
   * This is a support module — bindings are resolved on demand when referenced from intrinsic
   * bodies. IntrinsicsNativeList delegates to these methods.
@@ -17,7 +25,10 @@ import scalus.uplc.builtin.Builtins.*
 @Compile
 object NativeListOperations {
 
-    def map[A, B](self: List[A], mapper: A => B): List[B] = {
+    def map[
+        @UplcRepr(TypeVar(Unwrapped)) A,
+        @UplcRepr(TypeVar(Unwrapped)) B
+    ](self: List[A], mapper: A => B): List[B] = {
         val blist = typeProxy[BuiltinList[A]](self)
         def go(lst: BuiltinList[A]): List[B] =
             if nullList(lst) then List.Nil
@@ -29,7 +40,10 @@ object NativeListOperations {
         go(blist)
     }
 
-    def filter[A](self: List[A], predicate: A => Boolean): List[A] = {
+    def filter[@UplcRepr(TypeVar(Unwrapped)) A](
+        self: List[A],
+        predicate: A => Boolean
+    ): List[A] = {
         val blist = typeProxy[BuiltinList[A]](self)
         def go(lst: BuiltinList[A]): List[A] =
             if nullList(lst) then List.Nil
@@ -42,7 +56,10 @@ object NativeListOperations {
         go(blist)
     }
 
-    def foldLeft[A, B](self: List[A], init: B, combiner: (B, A) => B): B = {
+    def foldLeft[
+        @UplcRepr(TypeVar(Unwrapped)) A,
+        @UplcRepr(TypeVar(Unwrapped)) B
+    ](self: List[A], init: B, combiner: (B, A) => B): B = {
         val blist = typeProxy[BuiltinList[A]](self)
         def go(lst: BuiltinList[A], acc: B): B =
             if nullList(lst) then acc
@@ -54,7 +71,10 @@ object NativeListOperations {
         go(blist, init)
     }
 
-    def foldRight[A, B](self: List[A], init: B, combiner: (A, B) => B): B = {
+    def foldRight[
+        @UplcRepr(TypeVar(Unwrapped)) A,
+        @UplcRepr(TypeVar(Unwrapped)) B
+    ](self: List[A], init: B, combiner: (A, B) => B): B = {
         val blist = typeProxy[BuiltinList[A]](self)
         def go(lst: BuiltinList[A]): B =
             if nullList(lst) then init
@@ -79,7 +99,11 @@ object NativeListOperations {
         go(blist)
     }
 
-    def contains[A](self: List[A], elem: A, eq: (A, A) => Boolean): Boolean = {
+    def contains[@UplcRepr(TypeVar(Unwrapped)) A](
+        self: List[A],
+        elem: A,
+        eq: (A, A) => Boolean
+    ): Boolean = {
         val blist = typeProxy[BuiltinList[A]](self)
         def go(lst: BuiltinList[A]): Boolean =
             if nullList(lst) then false

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -324,7 +324,26 @@ object IntrinsicResolver {
                                             lctx.typeUnifyEnv.copy(filledTypes = merged)
                                         lctx.typeVarReprEnv = savedReprEnv
                                         allocatedKeys.foreach(lctx.argCache.remove)
-                                Some(lowered)
+                                // Apply rule only when the body's natural output and rule's
+                                // declared output are in different repr families — same-family
+                                // pairs (e.g. SumUplcConstr with Unwrapped vs concrete-default
+                                // element reprs) are runtime-equivalent and a `toRepresentation`
+                                // would just emit a redundant spine rewriter.
+                                val ruleApplied = bestReprRules.get(methodName) match
+                                    case Some(rule) =>
+                                        val outputRepr =
+                                            rule(appType, firstEffective.representation, lctx)
+                                        if reprsShareOuterFamily(
+                                              lowered.representation,
+                                              outputRepr
+                                            )
+                                        then lowered
+                                        else lowered.toRepresentation(outputRepr, pos)
+                                    case None => lowered
+                                Some(
+                                  RepresentationAnnotatedTypeProxyLoweredValue
+                                      .wrapIfAnnotated(ruleApplied, pos)
+                                )
                             }
                         }
     }
@@ -456,108 +475,24 @@ object IntrinsicResolver {
                                             lctx.typeUnifyEnv.copy(filledTypes = merged)
                                         lctx.typeVarReprEnv = savedReprEnv
                                 } finally lctx.argCache.remove(allocatedKey)
-                            val annotateReturnType = propagateReturnAnnotation
-                            // If the inlined body's sirType has free TypeVars (not bound by
-                            // any inner TypeLambda), wrap them with an outer TypeLambda. The
-                            // result of currying `map[A,B](self)` is conceptually
-                            // `[B] =>> (A→B) → List[B]` but the inlined body drops the wrapper.
-                            // Without it, downstream `lvApply.reprFun` short-circuits
-                            // (`collectPolyOrFun` returns `typeVars=Nil`) so it can't substitute
-                            // the actual mapper's output repr into the result list's element
-                            // repr — `Transparent` TypeVar reprs leak instead.
-                            def collectFreeTypeVars(tp: SIRType): scala.List[SIRType.TypeVar] = {
-                                val seen =
-                                    new java.util.IdentityHashMap[SIRType.TypeProxy, Boolean]()
-                                val acc =
-                                    scala.collection.mutable.LinkedHashSet[SIRType.TypeVar]()
-                                def go(t: SIRType, bound: Set[SIRType.TypeVar]): Unit =
-                                    t match
-                                        case tv: SIRType.TypeVar =>
-                                            if !bound.contains(tv) then acc += tv
-                                        case SIRType.TypeLambda(ps, body) =>
-                                            go(body, bound ++ ps)
-                                        case SIRType.Fun(in, out) =>
-                                            go(in, bound); go(out, bound)
-                                        case SIRType.CaseClass(_, args, parent) =>
-                                            args.foreach(go(_, bound))
-                                            parent.foreach(go(_, bound))
-                                        case SIRType.SumCaseClass(_, args) =>
-                                            args.foreach(go(_, bound))
-                                        case SIRType.Annotated(t1, _) => go(t1, bound)
-                                        case SIRType.TypeProxy(ref) =>
-                                            if ref != null && !seen.containsKey(t) then {
-                                                seen.put(t.asInstanceOf[SIRType.TypeProxy], true)
-                                                go(ref, bound)
-                                            }
-                                        case _ => // primitives, FreeUnificator, TypeNothing
-                                go(tp, Set.empty)
-                                acc.toList
-                            }
-                            def restoreTypeLambdaWrapper(base: SIRType): SIRType = {
-                                val frees = collectFreeTypeVars(base)
-                                if frees.isEmpty then base
-                                else SIRType.TypeLambda(frees, base)
-                            }
-                            val annotatedBase = effectiveArg.sirType match
-                                case SIRType.Annotated(_, anns) if anns.data.contains("uplcRepr") =>
-                                    annotateReturnType(lowered.sirType, anns)
-                                case _ => lowered.sirType
-                            val outputSirType =
-                                restoreTypeLambdaWrapper(annotatedBase)
-                            // Rebuild LambdaRepresentation so its `funTp` carries the outer
-                            // TypeLambda — `reprFun` at downstream applies needs it to see
-                            // the bound TypeVars and substitute their reprs.
-                            val wrappedRepr = lowered.representation match
-                                case lr: LambdaRepresentation if outputSirType ne lowered.sirType =>
-                                    LambdaRepresentation(
-                                      outputSirType,
-                                      lr.canonicalRepresentationPair
-                                    )
-                                case other => other
-                            // Apply repr rule to set correct output representation
-                            bestReprRules.get(methodName) match
+                            // Real byte-level conversion + representation-derived annotation +
+                            // outer TypeLambda restoration. Both proxies derive their fields
+                            // from `origin`, so neither label can drift from emitted bytes.
+                            val ruleApplied = bestReprRules.get(methodName) match
                                 case Some(rule) =>
                                     val outputRepr =
                                         rule(appType, effectiveArg.representation, lctx)
-                                    if lowered.representation == outputRepr
-                                        && outputSirType == lowered.sirType
+                                    if reprsShareOuterFamily(
+                                          lowered.representation,
+                                          outputRepr
+                                        )
                                     then lowered
-                                    else
-                                        new BaseRepresentationProxyLoweredValue(
-                                          lowered,
-                                          outputRepr,
-                                          pos
-                                        ) {
-                                            override def sirType: SIRType = outputSirType
-                                            override def termInternal(
-                                                gctx: TermGenerationContext
-                                            ): Term =
-                                                lowered.termInternal(gctx)
-                                            override def docDef(
-                                                ctx: LoweredValue.PrettyPrintingContext
-                                            ): Doc =
-                                                lowered.docRef(ctx)
-                                        }
-                                case None =>
-                                    if outputSirType == lowered.sirType
-                                        && (wrappedRepr eq lowered.representation)
-                                    then lowered
-                                    else
-                                        new BaseRepresentationProxyLoweredValue(
-                                          lowered,
-                                          wrappedRepr,
-                                          pos
-                                        ) {
-                                            override def sirType: SIRType = outputSirType
-                                            override def termInternal(
-                                                gctx: TermGenerationContext
-                                            ): Term =
-                                                lowered.termInternal(gctx)
-                                            override def docDef(
-                                                ctx: LoweredValue.PrettyPrintingContext
-                                            ): Doc =
-                                                lowered.docRef(ctx)
-                                        }
+                                    else lowered.toRepresentation(outputRepr, pos)
+                                case None => lowered
+                            val annotated =
+                                RepresentationAnnotatedTypeProxyLoweredValue
+                                    .wrapIfAnnotated(ruleApplied, pos)
+                            OuterTypeLambdaWrappedLoweredValue.wrapIfNeeded(annotated, pos)
                         }
     }
 
@@ -623,6 +558,42 @@ object IntrinsicResolver {
             case a: AnnotatedSIR      => goE(a)
         go(sir)
     }
+
+    /** True when both reprs share top-level spine kind, regardless of nested field-repr
+      * differences. Skips `toRepresentation` when source and target are runtime-equivalent (e.g.
+      * SumUplcConstr with `TypeVarRepresentation(Unwrapped)` element reprs aliasing the concrete
+      * default).
+      */
+    private def reprsShareOuterFamily(
+        a: LoweredValueRepresentation,
+        b: LoweredValueRepresentation
+    ): Boolean = (a, b) match
+        case (
+              _: SumCaseClassRepresentation.SumUplcConstr,
+              _: SumCaseClassRepresentation.SumUplcConstr
+            ) =>
+            true
+        case (
+              _: SumCaseClassRepresentation.SumBuiltinList,
+              _: SumCaseClassRepresentation.SumBuiltinList
+            ) =>
+            true
+        case (
+              _: SumCaseClassRepresentation.SumPairBuiltinList,
+              _: SumCaseClassRepresentation.SumPairBuiltinList
+            ) =>
+            true
+        case (
+              _: ProductCaseClassRepresentation.ProdUplcConstr,
+              _: ProductCaseClassRepresentation.ProdUplcConstr
+            ) =>
+            true
+        case (
+              _: ProductCaseClassRepresentation.ProdBuiltinPair,
+              _: ProductCaseClassRepresentation.ProdBuiltinPair
+            ) =>
+            true
+        case _ => a == b
 
     /** All representation names that match a given representation, most specific first. */
     private def representationNames(repr: LoweredValueRepresentation): List[String] = repr match

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -63,23 +63,31 @@ object IntrinsicResolver {
           "scalus.compiler.intrinsics.IntrinsicsUplcConstrList",
           "scalus.compiler.intrinsics.IntrinsicsUplcConstrOption"
         )
-        // All intrinsic modules carry author-written `@UplcRepr(TypeVar(...))` annotations on
-        // their type parameters, so no blanket post-load stamping is needed. HO function
-        // arguments (e.g. Eq in contains) are explicitly wrapped with toDefaultTypeVarRepr in
-        // the intrinsic body to convert to Fixed (Data) repr.
+        // Intrinsic modules that need a non-default TypeVar kind carry author-written
+        // `@UplcRepr(TypeVar(...))` annotations on their type parameters, so no blanket
+        // post-load stamping is needed. HO function arguments (e.g. Eq in contains) are
+        // explicitly wrapped with toDefaultTypeVarRepr in the intrinsic body to convert to
+        // Fixed (Data) repr.
         //   - IntrinsicsUplcConstrList:    `@UplcRepr(TypeVar(Unwrapped))`   (bytes at concrete default)
         //   - IntrinsicsUplcConstrOption:  `@UplcRepr(TypeVar(Transparent))` (bytes pass through)
         //   - IntrinsicsNativeList:        `@UplcRepr(TypeVar(Transparent))` (bytes pass through)
+        // Other intrinsic modules (e.g. BuiltinListOperations, BuiltinPairListOperations,
+        // SortedMapIntrinsics, AssocMapIntrinsics) load with default `Fixed` TypeVars — they
+        // operate on Data-encoded inputs and don't need passthrough semantics.
         modules
     }
 
     /** Support modules — bindings resolved on demand when referenced from intrinsic bodies. Unlike
       * intrinsic modules, these are NOT used for provider substitution.
       *
-      * All support modules carry author-written `@UplcRepr(TypeVar(...))` annotations on their
-      * type parameters, so no blanket post-load stamping is needed. For HO methods that take
-      * pre-compiled functions (like contains with Eq), the dispatcher wraps the HO function with
-      * representation conversion adapters.
+      * Methods that need a non-default TypeVar kind carry author-written
+      * `@UplcRepr(TypeVar(...))` annotations on their type parameters, so no blanket post-load
+      * stamping is needed. `NativeListOperations.find` is intentionally left unannotated (loads
+      * with default `Fixed`) — its `Option.None`/`Option.Some` if-then-else body has a
+      * known interaction with Constr emission that the annotation path doesn't yet handle (see
+      * its scaladoc for details). For HO methods that take pre-compiled functions (like
+      * contains with Eq), the dispatcher wraps the HO function with representation conversion
+      * adapters.
       */
     def defaultSupportModules: Map[String, Module] = {
         scalus.compiler.compiledModules(

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -80,14 +80,13 @@ object IntrinsicResolver {
     /** Support modules — bindings resolved on demand when referenced from intrinsic bodies. Unlike
       * intrinsic modules, these are NOT used for provider substitution.
       *
-      * Methods that need a non-default TypeVar kind carry author-written
-      * `@UplcRepr(TypeVar(...))` annotations on their type parameters, so no blanket post-load
-      * stamping is needed. `NativeListOperations.find` is intentionally left unannotated (loads
-      * with default `Fixed`) — its `Option.None`/`Option.Some` if-then-else body has a
-      * known interaction with Constr emission that the annotation path doesn't yet handle (see
-      * its scaladoc for details). For HO methods that take pre-compiled functions (like
-      * contains with Eq), the dispatcher wraps the HO function with representation conversion
-      * adapters.
+      * Methods that need a non-default TypeVar kind carry author-written `@UplcRepr(TypeVar(...))`
+      * annotations on their type parameters, so no blanket post-load stamping is needed.
+      * `NativeListOperations.find` is intentionally left unannotated (loads with default `Fixed`) —
+      * its `Option.None`/`Option.Some` if-then-else body has a known interaction with Constr
+      * emission that the annotation path doesn't yet handle (see its scaladoc for details). For HO
+      * methods that take pre-compiled functions (like contains with Eq), the dispatcher wraps the
+      * HO function with representation conversion adapters.
       */
     def defaultSupportModules: Map[String, Module] = {
         scalus.compiler.compiledModules(

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -63,59 +63,30 @@ object IntrinsicResolver {
           "scalus.compiler.intrinsics.IntrinsicsUplcConstrList",
           "scalus.compiler.intrinsics.IntrinsicsUplcConstrOption"
         )
-        // Stamp TypeVars Transparent so native values pass through without implicit Data
-        // conversion. HO function arguments (e.g. Eq in contains) are explicitly wrapped with
-        // toDefaultTypeVarRepr in the intrinsic body to convert to Fixed (Data) repr.
-        //
-        // UplcConstrListOps and UplcConstrOptionOps carry author-written `@UplcRepr(TypeVar(...))`
-        // annotations and bypass blanket stamping so the source intent is preserved:
+        // All intrinsic modules carry author-written `@UplcRepr(TypeVar(...))` annotations on
+        // their type parameters, so no blanket post-load stamping is needed. HO function
+        // arguments (e.g. Eq in contains) are explicitly wrapped with toDefaultTypeVarRepr in
+        // the intrinsic body to convert to Fixed (Data) repr.
         //   - IntrinsicsUplcConstrList:    `@UplcRepr(TypeVar(Unwrapped))`   (bytes at concrete default)
         //   - IntrinsicsUplcConstrOption:  `@UplcRepr(TypeVar(Transparent))` (bytes pass through)
-        // NativeListOps still uses the legacy blanket-Transparent path.
-        modules.map { (name, module) =>
-            if name == NativeListOps then name -> stampTransparent(module)
-            else name -> module
-        }
-    }
-
-    private def stampTransparent(module: Module): Module = {
-        val transparentDefs = module.defs.map { binding =>
-            val newValue = SIR.mapTypeVars(
-              binding.value,
-              _.copy(kind = SIRType.TypeVarKind.Transparent)
-            )
-            val newTp = SIRType.mapTypeVars(
-              binding.tp,
-              _.copy(kind = SIRType.TypeVarKind.Transparent)
-            )
-            Binding(binding.name, newTp, newValue)
-        }
-        module.copy(defs = transparentDefs)
+        //   - IntrinsicsNativeList:        `@UplcRepr(TypeVar(Transparent))` (bytes pass through)
+        modules
     }
 
     /** Support modules — bindings resolved on demand when referenced from intrinsic bodies. Unlike
       * intrinsic modules, these are NOT used for provider substitution.
       *
-      * `UplcConstrListOperations` and `UplcConstrOptionOperations` carry per-typeparam
-      * `@UplcRepr(TypeVar(Transparent))` so their TypeVars come through with author-written kinds,
-      * matching the dispatcher annotations and avoiding the abstract-A `Transparent → Unwrapped`
-      * boundary at standalone-lowered support-op call sites. `NativeListOperations` is still on the
-      * legacy blanket-Transparent path until Phase 4 migrates it.
+      * All support modules carry author-written `@UplcRepr(TypeVar(...))` annotations on their
+      * type parameters, so no blanket post-load stamping is needed. For HO methods that take
+      * pre-compiled functions (like contains with Eq), the dispatcher wraps the HO function with
+      * representation conversion adapters.
       */
     def defaultSupportModules: Map[String, Module] = {
-        val modules = scalus.compiler.compiledModules(
+        scalus.compiler.compiledModules(
           "scalus.compiler.intrinsics.NativeListOperations",
           "scalus.compiler.intrinsics.UplcConstrListOperations",
           "scalus.compiler.intrinsics.UplcConstrOptionOperations"
         )
-        // Skip stamping for modules whose type parameters carry @UplcRepr annotations.
-        // For HO methods that take pre-compiled functions (like contains with Eq), the
-        // dispatcher wraps the HO function with representation conversion adapters.
-        modules.map { (name, module) =>
-            if name == "scalus.compiler.intrinsics.NativeListOperations" then
-                name -> stampTransparent(module)
-            else name -> module
-        }
     }
 
     // Representation name constants for registry lookup

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/RepresentationProxyLoweredValue.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/RepresentationProxyLoweredValue.scala
@@ -3,6 +3,7 @@ package scalus.compiler.sir.lowering
 import org.typelevel.paiges.Doc
 import scalus.compiler.sir.*
 import scalus.uplc.*
+import scala.util.control.NonFatal
 
 abstract class BaseRepresentationProxyLoweredValue(
     input: LoweredValue,
@@ -70,6 +71,217 @@ object RepresentationProxyLoweredValue {
                 new RepresentationProxyLoweredValue(input, representation, pos)
     }
 
+}
+
+/** Proxy whose `sirType` is `origin.sirType` with an `@UplcRepr` annotation derived from the
+  * value's actual `representation`, attached at the return / scalar position. `representation` is
+  * inherited from `origin`, so the annotation can never drift from the emitted bytes.
+  */
+final class RepresentationAnnotatedTypeProxyLoweredValue private (
+    input: LoweredValue,
+    annotated: SIRType,
+    inPos: SIRPosition
+) extends ProxyLoweredValue(input) {
+
+    override def sirType: SIRType = annotated
+    override def pos: SIRPosition = inPos
+    override def termInternal(gctx: TermGenerationContext): Term = input.termInternal(gctx)
+
+    override def docDef(ctx: LoweredValue.PrettyPrintingContext): Doc = {
+        val left = Doc.text("repr.annotated.type.proxy") + Doc.text("(")
+        val right = Doc.text(":") + Doc.text(sirType.show) + Doc.text(")")
+        input.docRef(ctx).bracketBy(left, right)
+    }
+    override def docRef(ctx: LoweredValue.PrettyPrintingContext): Doc = docDef(ctx)
+}
+
+object RepresentationAnnotatedTypeProxyLoweredValue {
+
+    /** Wrap when the representation has a non-default surface `@UplcRepr` form; otherwise return
+      * `input` verbatim (proxy would be a hot-path no-op).
+      */
+    def wrapIfAnnotated(input: LoweredValue, inPos: SIRPosition)(using
+        LoweringContext
+    ): LoweredValue = {
+        val annotated = annotateAtReturn(input.sirType, input.representation, inPos)
+        if annotated eq input.sirType then input
+        else new RepresentationAnnotatedTypeProxyLoweredValue(input, annotated, inPos)
+    }
+
+    /** Attach an `@UplcRepr` annotation derived from `repr` at `tp`'s return / scalar position.
+      * Returns `tp` unchanged when `repr` is the type's natural default, has no surface form, or
+      * computing the type's default fails (e.g. unresolved typeGenerator).
+      */
+    def annotateAtReturn(
+        tp: SIRType,
+        repr: LoweredValueRepresentation,
+        pos: SIRPosition
+    )(using LoweringContext): SIRType = annotationForRepresentation(tp, repr, pos) match
+        case Some(anns) => IntrinsicResolver.propagateReturnAnnotation(tp, anns)
+        case None       => tp
+
+    private def annotationForRepresentation(
+        tp: SIRType,
+        repr: LoweredValueRepresentation,
+        pos: SIRPosition
+    )(using lctx: LoweringContext): Option[scalus.compiler.sir.AnnotationsDecl] = {
+        // Skip the type-default fast path for reprs that obviously have no surface form.
+        // Avoids running `defaultRepresentation` (the expensive part) on the common cases
+        // where the encoder would return None anyway.
+        encodeReprAsAnnotationValue(tp, repr, pos).flatMap { sir =>
+            // No override needed when repr already matches the type's natural default.
+            val typeDefault =
+                try Some(lctx.typeGenerator(tp).defaultRepresentation(tp)(using lctx))
+                catch case NonFatal(_) => None
+            if typeDefault.contains(repr) then None
+            else
+                Some(
+                  scalus.compiler.sir.AnnotationsDecl(pos, data = Map("uplcRepr" -> sir))
+                )
+        }
+    }
+
+    /** Encode `repr` as the SIR value placed under the `"uplcRepr"` annotation key, mirroring
+      * `SIRTyper.encodeReprTag`'s output so `SirTypeUplcGenerator.resolveReprAnnotation` reads it
+      * back to the same repr. Returns `None` for reprs without a surface form — their full detail
+      * lives on the lowered value's `representation` field, where downstream consumers read it
+      * directly.
+      */
+    private def encodeReprAsAnnotationValue(
+        tp: SIRType,
+        repr: LoweredValueRepresentation,
+        pos: SIRPosition
+    )(using LoweringContext): Option[SIR] = {
+        def stringSentinel(name: String): SIR =
+            SIR.Const(
+              scalus.uplc.Constant.String(name),
+              SIRType.String,
+              scalus.compiler.sir.AnnotationsDecl(pos)
+            )
+
+        def constrSir(shortName: String, args: scala.List[SIR]): SIR = {
+            val constrDecl = scalus.compiler.sir.ConstrDecl(
+              shortName,
+              args.map(_ => scalus.compiler.sir.TypeBinding("arg", SIRType.FreeUnificator)),
+              Nil,
+              Nil,
+              scalus.compiler.sir.AnnotationsDecl.emptyModule
+            )
+            val dataDecl = scalus.compiler.sir.DataDecl(
+              shortName,
+              scala.List(constrDecl),
+              Nil,
+              scalus.compiler.sir.AnnotationsDecl.emptyModule
+            )
+            SIR.Constr(
+              shortName,
+              dataDecl,
+              args,
+              SIRType.SumCaseClass(dataDecl, Nil),
+              scalus.compiler.sir.AnnotationsDecl(pos)
+            )
+        }
+
+        repr match
+            case _: SumCaseClassRepresentation.SumUplcConstr =>
+                Some(stringSentinel("UplcConstr"))
+            case SumCaseClassRepresentation.DataConstr =>
+                Some(stringSentinel("DataConstr"))
+            case SumCaseClassRepresentation.DataData =>
+                Some(stringSentinel("DataData"))
+            case SumCaseClassRepresentation.PackedSumDataList =>
+                Some(stringSentinel("PackedSumDataList"))
+            case PrimitiveRepresentation.Constant =>
+                Some(stringSentinel("Constant"))
+            case PrimitiveRepresentation.PackedData =>
+                Some(stringSentinel("PackedData"))
+            case SumCaseClassRepresentation.SumBuiltinList(elemRepr) =>
+                val elemTp = SumCaseClassRepresentation.SumBuiltinList
+                    .retrieveListElementType(tp)
+                    .getOrElse(SIRType.Data.tp)
+                encodeReprAsAnnotationValue(elemTp, elemRepr, pos).map { argSir =>
+                    constrSir("SumBuiltinList", scala.List(argSir))
+                }
+            case ProductCaseClassRepresentation.ProdBuiltinPair(fstRepr, sndRepr) =>
+                val (fstTp, sndTp) =
+                    ProductCaseClassRepresentation.ProdBuiltinPair
+                        .extractPairComponentTypes(tp)
+                for {
+                    fstSir <- encodeReprAsAnnotationValue(fstTp, fstRepr, pos)
+                    sndSir <- encodeReprAsAnnotationValue(sndTp, sndRepr, pos)
+                } yield constrSir("ProdBuiltinPair", scala.List(fstSir, sndSir))
+            // No surface annotation form for the rest — full detail lives on the
+            // `representation` field; absence here is correct, not lossy.
+            case _ => None
+    }
+}
+
+/** Proxy wrapping the value's `sirType` with an outer `TypeLambda` binding free TypeVars not bound
+  * by any inner `TypeLambda`. When the underlying value is a Lambda, its
+  * `LambdaRepresentation.funTp` is rewrapped consistently so `representation.funTp == sirType`.
+  * Used when an inlined intrinsic body has dropped its outer `TypeLambda` and downstream
+  * `lvApply.reprFun` needs the bound TypeVars to resolve element reprs.
+  */
+final class OuterTypeLambdaWrappedLoweredValue private (
+    input: LoweredValue,
+    freeVars: scala.List[SIRType.TypeVar],
+    inPos: SIRPosition
+) extends ProxyLoweredValue(input) {
+
+    override val sirType: SIRType = SIRType.TypeLambda(freeVars, input.sirType)
+
+    override val representation: LoweredValueRepresentation =
+        input.representation match
+            case lr: LambdaRepresentation =>
+                LambdaRepresentation(sirType, lr.canonicalRepresentationPair)
+            case other => other
+
+    override def pos: SIRPosition = inPos
+    override def termInternal(gctx: TermGenerationContext): Term = input.termInternal(gctx)
+
+    override def docDef(ctx: LoweredValue.PrettyPrintingContext): Doc = {
+        val left = Doc.text("outer.tlam.proxy") + Doc.text("(")
+        val right = Doc.text(":") + Doc.text(sirType.show) + Doc.text(")")
+        input.docRef(ctx).bracketBy(left, right)
+    }
+    override def docRef(ctx: LoweredValue.PrettyPrintingContext): Doc = docDef(ctx)
+}
+
+object OuterTypeLambdaWrappedLoweredValue {
+
+    /** Wrap when `input.sirType` has free TypeVars; otherwise return `input` verbatim. */
+    def wrapIfNeeded(input: LoweredValue, inPos: SIRPosition): LoweredValue = {
+        val frees = collectFreeTypeVars(input.sirType)
+        if frees.isEmpty then input
+        else new OuterTypeLambdaWrappedLoweredValue(input, frees, inPos)
+    }
+
+    /** Collect TypeVars referenced in `tp` that are NOT bound by any inner `TypeLambda`. */
+    def collectFreeTypeVars(tp: SIRType): scala.List[SIRType.TypeVar] = {
+        val seen = new java.util.IdentityHashMap[SIRType.TypeProxy, Boolean]()
+        val acc = scala.collection.mutable.LinkedHashSet[SIRType.TypeVar]()
+        def go(t: SIRType, bound: Set[SIRType.TypeVar]): Unit = t match
+            case tv: SIRType.TypeVar =>
+                if !bound.contains(tv) then acc += tv
+            case SIRType.TypeLambda(ps, body) =>
+                go(body, bound ++ ps)
+            case SIRType.Fun(in, out) =>
+                go(in, bound); go(out, bound)
+            case SIRType.CaseClass(_, args, parent) =>
+                args.foreach(go(_, bound))
+                parent.foreach(go(_, bound))
+            case SIRType.SumCaseClass(_, args) =>
+                args.foreach(go(_, bound))
+            case SIRType.Annotated(t1, _) => go(t1, bound)
+            case SIRType.TypeProxy(ref) =>
+                if ref != null && !seen.containsKey(t) then {
+                    seen.put(t.asInstanceOf[SIRType.TypeProxy], true)
+                    go(ref, bound)
+                }
+            case _ => // primitives, FreeUnificator, TypeNothing
+        go(tp, Set.empty)
+        acc.toList
+    }
 }
 
 /** A proxy which changes the input value to be specific type and representation.

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrSirTypeGenerator.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrSirTypeGenerator.scala
@@ -162,13 +162,35 @@ object SumCaseUplcConstrSirTypeGenerator extends SirTypeUplcGenerator {
         loweredArgs: scala.List[LoweredValue],
         optTargetType: Option[SIRType]
     )(using lctx: LoweringContext): LoweredValue = {
-        // Resolve the concrete CaseClass type from the SumCaseClass
-        val caseClassType = constr.data.constrType(constr.name)
+        // `genConstrUplcConstr` needs a CaseClass tp. After `dispatchNil` `constr.tp` may be a
+        // sum target (possibly `Annotated`) carrying caller-supplied substituted args — preserve
+        // them as the rebuilt CaseClass's parent rather than dropping them via the static
+        // `decl.constrType(name)` lookup (which would substitute back to abstract decl typevars).
+        val effectiveTp =
+            if SIRType.isProd(constr.tp) then constr.tp
+            else if SIRType.isSum(constr.tp) then
+                preservedParentCaseClassForm(constr.tp, constr.data, constr.name)
+            else constr.data.constrType(constr.name)
         ProductCaseSirTypeGenerator.genConstrUplcConstr(
-          constr.copy(tp = caseClassType),
+          constr.copy(tp = effectiveTp),
           loweredArgs
         )
     }
+
+    /** Build a CaseClass form for `ctorName` using `parent` as its parent field, preserving any
+      * `Annotated`/substituted args on `parent`. The constructor's own shape (typeParams, typeArgs)
+      * comes from `decl.constrType(ctorName)`; only the parent reference is swapped.
+      */
+    private def preservedParentCaseClassForm(
+        parent: SIRType,
+        decl: scalus.compiler.sir.DataDecl,
+        ctorName: String
+    ): SIRType = decl.constrType(ctorName) match
+        case SIRType.TypeLambda(params, SIRType.CaseClass(c, args, _)) =>
+            SIRType.TypeLambda(params, SIRType.CaseClass(c, args, Some(parent)))
+        case SIRType.CaseClass(c, args, _) =>
+            SIRType.CaseClass(c, args, Some(parent))
+        case other => other
 
     override def genSelect(sel: SIR.Select, loweredScrutinee: LoweredValue)(using
         lctx: LoweringContext

--- a/scalus-core/shared/src/test/scala/scalus/compiler/sir/lowering/NativeListFindTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/compiler/sir/lowering/NativeListFindTest.scala
@@ -1,0 +1,64 @@
+package scalus.compiler.sir.lowering
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.*
+import scalus.cardano.ledger.MajorProtocolVersion
+import scalus.cardano.onchain.plutus.prelude.*
+import scalus.compiler.{compile, Compile, Options, UplcRepr, UplcRepresentation}
+import scalus.compiler.UplcRepresentation.TypeVar
+import scalus.compiler.UplcRepresentation.TypeVarKind.Transparent
+import scalus.uplc.{Constant, Term}
+import scalus.uplc.eval.{PlutusVM, Result}
+
+@Compile
+object NativeFindModule {
+
+    /** `@UplcRepr(TypeVar(Transparent))` makes `xs` lower with
+      * `SumBuiltinList(TypeVarRepresentation(Transparent))` repr (non-PackedData), so the inner
+      * `xs.find(...)` dispatches through `IntrinsicsNativeList.find`. The predicate doesn't
+      * dereference the element so the test is independent of Transparent-A passthrough semantics at
+      * the predicate boundary.
+      */
+    def transparentFindAny[@UplcRepr(TypeVar(Transparent)) A](
+        xs: List[A]
+    ): Boolean = xs.find(_ => true) match
+        case Option.Some(_) => true
+        case Option.None    => false
+}
+
+/** Exercises `IntrinsicsNativeList.find` dispatch — unreachable from the rest of the suite. */
+class NativeListFindTest extends AnyFunSuite {
+
+    private given PlutusVM = PlutusVM.makePlutusV3VM(MajorProtocolVersion.vanRossemPV)
+    private given Options = Options(
+      targetLoweringBackend = scalus.compiler.sir.TargetLoweringBackend.SirToUplcV3Lowering,
+      targetProtocolVersion = MajorProtocolVersion.vanRossemPV
+    )
+
+    test("transparentFindAny on non-empty list → true (Some branch)") {
+        val sir = compile {
+            val xs = List[BigInt](BigInt(10), BigInt(20))
+            NativeFindModule.transparentFindAny[BigInt](xs)
+        }
+        sir.toUplc().evaluateDebug match
+            case Result.Success(Term.Const(Constant.Bool(b), _), _, _, _) =>
+                assert(b == true, s"Expected true (Some branch), got $b")
+            case Result.Success(term, _, _, _) =>
+                fail(s"Expected Bool, got ${term.show}")
+            case Result.Failure(ex, _, _, _) =>
+                fail(s"transparentFindAny non-empty failed: $ex")
+    }
+
+    test("transparentFindAny on empty list → false (None branch)") {
+        val sir = compile {
+            NativeFindModule.transparentFindAny[BigInt](List.empty[BigInt])
+        }
+        sir.toUplc().evaluateDebug match
+            case Result.Success(Term.Const(Constant.Bool(b), _), _, _, _) =>
+                assert(b == false, s"Expected false (None branch), got $b")
+            case Result.Success(term, _, _, _) =>
+                fail(s"Expected Bool, got ${term.show}")
+            case Result.Failure(ex, _, _, _) =>
+                fail(s"transparentFindAny empty failed: $ex")
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the legacy post-load \`stampTransparent\` TypeVar-kind rewriter with author-written \`@UplcRepr(TypeVar(...))\` annotations on \`IntrinsicsNativeList\` and \`NativeListOperations\`, and delete the helper.
- Discovered along the way: the \`stampTransparent\` call for the support module (\`defaultSupportModules\`, line 115) had a string-mismatch typo (missing trailing \`$\` object suffix) and had **never run** — \`NativeListOperations\` always loaded with \`Fixed\` TypeVars by accident. The intrinsic-module call at line 76 was active.
- Annotation choices preserve historical semantics:
  - \`IntrinsicsNativeList\`: \`@UplcRepr(TypeVar(Transparent))\` — matches what the working line-76 stamp produced.
  - \`NativeListOperations\`: \`@UplcRepr(TypeVar(Unwrapped))\` — \`Unwrapped\` falls through \`defaultDataRepresentation\` to \`TypeVarRepresentation(Fixed)\` (matching the historical accidental Fixed-default), avoiding the new fast-fail that \`Transparent\` would trip at \`TypeVarSirTypeGenerator.scala:38\`.

## Out of scope (follow-up)

\`find\` is intentionally left unannotated in both modules. Its \`Option.None\`/\`Option.Some\` if-then-else body exposes a separate Layer-4 lowering issue: \`SumCaseUplcConstrSirTypeGenerator.genConstrLowered:167\` overrides \`dispatchNil\`'s tp-substitution via \`constr.data.constrType(name)\`, so \`Option.None\` doesn't propagate the parent-sum's annotated type-args downstream. With \`find\` unannotated it loads with default \`Fixed A\` and lowers cleanly, matching pre-PR behavior.

## Test plan

- [x] \`sbtn scalusJVM/test\` — 3184/3184 ✅
- [x] \`sbtn scalusExamplesJVM/test\` — 432/432 ✅
- [x] \`scalusExamplesJVM/testOnly scalus.benchmarks.KnightsTest\` — 4/4 ✅
- [x] \`scalusExamplesJVM/testOnly scalus.benchmarks.KnightsTestMinimal\` — 22/22 ✅
- [ ] CI green