### PR TITLE
feat(ledger): add Script.PlutusV4 case for Dijkstra-era ref-scripts

### DIFF
--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -75,6 +75,16 @@ trait PlutusScriptEvaluator {
 
 object PlutusScriptEvaluator {
 
+    /** Reject a Plutus V4 script with a non-fatal `UnsupportedOperationException`. Plutus V4
+      * (Dijkstra) evaluation, context building, and diagnostic replay are all out of scope until
+      * the upstream `plutus-core` V4 work lands; this helper centralises the rejection so all
+      * three V4 dispatch sites share one message and one exception type.
+      */
+    private def unsupportedV4: Nothing =
+        throw new UnsupportedOperationException(
+          "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
+        )
+
     /** Build all script contexts for Plutus scripts in a transaction without evaluation.
       *
       * This method extracts all Plutus script redeemers from a transaction and builds their
@@ -95,6 +105,8 @@ object PlutusScriptEvaluator {
       *   Map from Redeemer to ScriptContext (union type: v1 | v2 | v3)
       * @throws java.lang.IllegalStateException
       *   if script resolution fails or required data is missing
+      * @throws java.lang.UnsupportedOperationException
+      *   if any redeemer's script is `Script.PlutusV4` — V4 evaluation is not yet implemented
       */
     def buildScriptContexts(
         tx: Transaction,
@@ -143,10 +155,7 @@ object PlutusScriptEvaluator {
                     case _: Script.PlutusV3 =>
                         val scriptInfo = getScriptInfoV3(tx, redeemer, datum)
                         v3.ScriptContext(txInfoV3, redeemer.data, scriptInfo)
-                    case _: Script.PlutusV4 =>
-                        throw new NotImplementedError(
-                          "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
-                        )
+                    case _: Script.PlutusV4 => unsupportedV4
                 redeemer -> context
         }.toMap
     }
@@ -410,10 +419,7 @@ object PlutusScriptEvaluator {
                             case ps: Script.PlutusV3 =>
                                 evalPlutusV3Script(tx, txInfoV3, redeemer, ps, datum, debugScripts)
 
-                            case _: Script.PlutusV4 =>
-                                throw new NotImplementedError(
-                                  "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
-                                )
+                            case _: Script.PlutusV4 => unsupportedV4
 
                         val cost = result._1.budget
                         log.debug(s"Evaluation result: $result")
@@ -671,10 +677,7 @@ object PlutusScriptEvaluator {
                             case _: Script.PlutusV1 => plutusV1VM
                             case _: Script.PlutusV2 => plutusV2VM
                             case _: Script.PlutusV3 => plutusV3VM
-                            case _: Script.PlutusV4 =>
-                                throw new NotImplementedError(
-                                  "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
-                                )
+                            case _: Script.PlutusV4 => unsupportedV4
                         val replaySpender = CountingBudgetSpender()
                         val replayLogger = Log()
                         var replayFailed = false

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -77,8 +77,8 @@ object PlutusScriptEvaluator {
 
     /** Reject a Plutus V4 script with a non-fatal `UnsupportedOperationException`. Plutus V4
       * (Dijkstra) evaluation, context building, and diagnostic replay are all out of scope until
-      * the upstream `plutus-core` V4 work lands; this helper centralises the rejection so all
-      * three V4 dispatch sites share one message and one exception type.
+      * the upstream `plutus-core` V4 work lands; this helper centralises the rejection so all three
+      * V4 dispatch sites share one message and one exception type.
       */
     private def unsupportedV4: Nothing =
         throw new UnsupportedOperationException(

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -143,6 +143,10 @@ object PlutusScriptEvaluator {
                     case _: Script.PlutusV3 =>
                         val scriptInfo = getScriptInfoV3(tx, redeemer, datum)
                         v3.ScriptContext(txInfoV3, redeemer.data, scriptInfo)
+                    case _: Script.PlutusV4 =>
+                        throw new NotImplementedError(
+                          "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
+                        )
                 redeemer -> context
         }.toMap
     }
@@ -406,6 +410,11 @@ object PlutusScriptEvaluator {
                             case ps: Script.PlutusV3 =>
                                 evalPlutusV3Script(tx, txInfoV3, redeemer, ps, datum, debugScripts)
 
+                            case _: Script.PlutusV4 =>
+                                throw new NotImplementedError(
+                                  "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
+                                )
+
                         val cost = result._1.budget
                         log.debug(s"Evaluation result: $result")
 
@@ -662,6 +671,10 @@ object PlutusScriptEvaluator {
                             case _: Script.PlutusV1 => plutusV1VM
                             case _: Script.PlutusV2 => plutusV2VM
                             case _: Script.PlutusV3 => plutusV3VM
+                            case _: Script.PlutusV4 =>
+                                throw new NotImplementedError(
+                                  "Plutus V4 (Dijkstra) script evaluation is not yet implemented"
+                                )
                         val replaySpender = CountingBudgetSpender()
                         val replayLogger = Log()
                         var replayFailed = false

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/StepError.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/StepError.scala
@@ -255,4 +255,15 @@ object StepError {
         override def explain: String =
             s"Deferred step resolution failed: ${cause.getMessage}"
     }
+
+    /** A step referenced a Plutus script whose language version the builder cannot yet attach to
+      * the witness set. Currently emitted only for `Language.PlutusV4` (Dijkstra), which needs the
+      * upcoming `plutusV4Scripts` witness-set field; the error gives callers a typed signal
+      * instead of a raw exception escaping the step processor.
+      */
+    case class UnsupportedPlutusVersion(language: Language, step: TransactionBuilderStep)
+        extends StepError {
+        override def explain: String =
+            s"Plutus $language scripts are not yet supported by the transaction builder."
+    }
 }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/StepError.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/StepError.scala
@@ -258,8 +258,8 @@ object StepError {
 
     /** A step referenced a Plutus script whose language version the builder cannot yet attach to
       * the witness set. Currently emitted only for `Language.PlutusV4` (Dijkstra), which needs the
-      * upcoming `plutusV4Scripts` witness-set field; the error gives callers a typed signal
-      * instead of a raw exception escaping the step processor.
+      * upcoming `plutusV4Scripts` witness-set field; the error gives callers a typed signal instead
+      * of a raw exception escaping the step processor.
       */
     case class UnsupportedPlutusVersion(language: Language, step: TransactionBuilderStep)
         extends StepError {

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionStepsProcessor.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionStepsProcessor.scala
@@ -247,7 +247,7 @@ private class TransactionStepsProcessor(private var _ctx: Context) {
                           plutus.scriptSource,
                           spend
                         )
-                        _ = usePlutusScript(plutus.scriptSource)
+                        _ <- usePlutusScript(plutus.scriptSource, spend)
 
                         detachedRedeemer = DetachedRedeemer(
                           DelayedRedeemerPlaceholder,
@@ -979,8 +979,8 @@ private class TransactionStepsProcessor(private var _ctx: Context) {
                           cred,
                           step
                         )
+                        _ <- usePlutusScript(witness.scriptSource, step)
                     } yield {
-                        usePlutusScript(witness.scriptSource)
                         val purpose = credAction match {
                             case Operation.Withdraw(stakeAddress) =>
                                 RedeemerPurpose.ForReward(RewardAccount(stakeAddress))
@@ -1146,41 +1146,48 @@ private class TransactionStepsProcessor(private var _ctx: Context) {
     }
 
     private def usePlutusScript(
-        plutusScript: ScriptSource[PlutusScript]
-    ): Unit = {
+        plutusScript: ScriptSource[PlutusScript],
+        step: TransactionBuilderStep
+    ): Result[Unit] = {
         plutusScript match {
             case ScriptSource.PlutusScriptValue(ps: PlutusScript) =>
                 // Add the script value to the appropriate field
-                val f = ps match {
+                ps match {
                     case v1: Script.PlutusV1 =>
-                        unsafeCtxWitnessL
-                            .refocus(_.plutusV1Scripts)
-                            .modify(s =>
-                                TaggedSortedStrictMap(s.toSortedMap.updated(v1.scriptHash, v1))
-                            )
+                        modify0(
+                          unsafeCtxWitnessL
+                              .refocus(_.plutusV1Scripts)
+                              .modify(s =>
+                                  TaggedSortedStrictMap(s.toSortedMap.updated(v1.scriptHash, v1))
+                              )
+                        )
+                        Ok
                     case v2: Script.PlutusV2 =>
-                        unsafeCtxWitnessL
-                            .refocus(_.plutusV2Scripts)
-                            .modify(s =>
-                                TaggedSortedStrictMap(s.toSortedMap.updated(v2.scriptHash, v2))
-                            )
+                        modify0(
+                          unsafeCtxWitnessL
+                              .refocus(_.plutusV2Scripts)
+                              .modify(s =>
+                                  TaggedSortedStrictMap(s.toSortedMap.updated(v2.scriptHash, v2))
+                              )
+                        )
+                        Ok
                     case v3: Script.PlutusV3 =>
-                        unsafeCtxWitnessL
-                            .refocus(_.plutusV3Scripts)
-                            .modify(s =>
-                                TaggedSortedStrictMap(s.toSortedMap.updated(v3.scriptHash, v3))
-                            )
+                        modify0(
+                          unsafeCtxWitnessL
+                              .refocus(_.plutusV3Scripts)
+                              .modify(s =>
+                                  TaggedSortedStrictMap(s.toSortedMap.updated(v3.scriptHash, v3))
+                              )
+                        )
+                        Ok
                     // PlutusV4 (Dijkstra) needs a `plutusV4Scripts` witness-set field that
                     // tracks the upcoming CDDL update; that ships with the on-chain tx
                     // wire-format work, not in this Script ADT-only PR.
                     case _: Script.PlutusV4 =>
-                        throw new NotImplementedError(
-                          "Plutus V4 (Dijkstra) tx-builder support is not yet implemented"
-                        )
+                        Left(StepError.UnsupportedPlutusVersion(Language.PlutusV4, step))
                 }
-                modify0(f)
             // Script should already be attached, see [[assertAttachedScriptExists]]
-            case ScriptSource.PlutusScriptAttached => ()
+            case ScriptSource.PlutusScriptAttached => Ok
         }
     }
 

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionStepsProcessor.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/txbuilder/TransactionStepsProcessor.scala
@@ -1170,6 +1170,13 @@ private class TransactionStepsProcessor(private var _ctx: Context) {
                             .modify(s =>
                                 TaggedSortedStrictMap(s.toSortedMap.updated(v3.scriptHash, v3))
                             )
+                    // PlutusV4 (Dijkstra) needs a `plutusV4Scripts` witness-set field that
+                    // tracks the upcoming CDDL update; that ships with the on-chain tx
+                    // wire-format work, not in this Script ADT-only PR.
+                    case _: Script.PlutusV4 =>
+                        throw new NotImplementedError(
+                          "Plutus V4 (Dijkstra) tx-builder support is not yet implemented"
+                        )
                 }
                 modify0(f)
             // Script should already be attached, see [[assertAttachedScriptExists]]

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/Script.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/Script.scala
@@ -143,6 +143,28 @@ object Script {
         }
     }
 
+    /** Plutus V4 script (introduced in the Dijkstra hard fork). */
+    @key(4) final case class PlutusV4(override val script: ByteString) extends PlutusScript
+        derives Codec {
+
+        /** Get the script hash for this Plutus V4 script */
+        @transient lazy val scriptHash: ScriptHash = Hash(
+          platform.blake2b_224(ByteString.unsafeFromArray(4 +: script.bytes))
+        )
+
+        def language: Language = Language.PlutusV4
+    }
+
+    object PlutusV4 {
+
+        /** Create from an in-memory Program, caching it to preserve source annotations. */
+        def apply(program: Program): PlutusV4 = {
+            val s = new PlutusV4(program.cborByteString)
+            s._cachedProgram = program
+            s
+        }
+    }
+
     given Codec[Script] = deriveCodec
 
     import Doc.*
@@ -157,10 +179,12 @@ object Script {
                 case Script.PlutusV1(_) => text("PlutusV1") + hashDoc
                 case Script.PlutusV2(_) => text("PlutusV2") + hashDoc
                 case Script.PlutusV3(_) => text("PlutusV3") + hashDoc
+                case Script.PlutusV4(_) => text("PlutusV4") + hashDoc
 
     // Variant instances delegate to the main Pretty[Script]
     given Pretty[Script.Native] = (a, style) => prettyScript.pretty(a, style)
     given Pretty[Script.PlutusV1] = (a, style) => prettyScript.pretty(a, style)
     given Pretty[Script.PlutusV2] = (a, style) => prettyScript.pretty(a, style)
     given Pretty[Script.PlutusV3] = (a, style) => prettyScript.pretty(a, style)
+    given Pretty[Script.PlutusV4] = (a, style) => prettyScript.pretty(a, style)
 }

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/ScriptRef.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/ScriptRef.scala
@@ -52,4 +52,6 @@ object ScriptRef:
                   ctr("PlutusV2", style) + inParens(text(s.toHex))
               case Script.PlutusV3(s) =>
                   ctr("PlutusV3", style) + inParens(text(s.toHex))
+              case Script.PlutusV4(s) =>
+                  ctr("PlutusV4", style) + inParens(text(s.toHex))
     )

--- a/scalus-core/shared/src/test/scala/scalus/cardano/ledger/ArbitraryInstances.scala
+++ b/scalus-core/shared/src/test/scala/scalus/cardano/ledger/ArbitraryInstances.scala
@@ -319,6 +319,7 @@ trait ArbitraryInstances extends scalus.cardano.address.ArbitraryInstances {
           arbitrary[Script.PlutusV1],
           arbitrary[Script.PlutusV2],
           arbitrary[Script.PlutusV3],
+          arbitrary[Script.PlutusV4],
         )
     }
     given Arbitrary[ScriptRef] = autoDerived
@@ -518,6 +519,11 @@ trait ArbitraryInstances extends scalus.cardano.address.ArbitraryInstances {
     given Arbitrary[Script.PlutusV3] = Arbitrary {
         for bytes <- genByteStringOfN(32)
         yield Script.PlutusV3(bytes)
+    }
+
+    given Arbitrary[Script.PlutusV4] = Arbitrary {
+        for bytes <- genByteStringOfN(32)
+        yield Script.PlutusV4(bytes)
     }
 
     given [A: Arbitrary]: Arbitrary[TaggedOrderedSet[A]] = Arbitrary(

--- a/scalus-core/shared/src/test/scala/scalus/utils/PrettyTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/utils/PrettyTest.scala
@@ -201,6 +201,13 @@ class PrettyTest extends AnyFunSuite {
         assert(result.startsWith("PlutusV3("))
     }
 
+    test("Pretty[Script] PlutusV4") {
+        val scriptBytes = ByteString.fromHex("4e4d0100003322222005")
+        val script: Script = Script.PlutusV4(scriptBytes)
+        val result = script.show
+        assert(result.startsWith("PlutusV4("))
+    }
+
     // === VKeyWitness Tests ===
 
     test("Pretty[VKeyWitness] shows vkey hash") {


### PR DESCRIPTION
## Summary
- Adds `Script.PlutusV4(script: ByteString) extends PlutusScript` mirroring `PlutusV3`; `@key(4)` lets the existing `deriveCodec` sum codec pick it up automatically.
- `Pretty[Script]`, `Pretty[ScriptRef]`, and `Arbitrary[Script]` now cover the new case.
- `PlutusScriptEvaluator` and `TransactionStepsProcessor` raise `NotImplementedError` on `Script.PlutusV4` — full V4 evaluation semantics (plutus-core upstream) and the `plutusV4Scripts` witness-set field (CDDL update) are out of scope and tracked separately.

## Why
`Language.PlutusV4` and `MajorProtocolVersion.dijkstraPV` already exist on `master`, but the `Script` ADT had no V4 case, so anything decoding a post-Dijkstra `PlutusScript` had nowhere to put it and had to reject it. Concretely, `scalus3/scalus-node`'s mithril snapshot restore (`MemPackReaders.readPlutusScript`) currently throws `UnsupportedTxOutVariant` on tag 3 — once Dijkstra hard-forks (preview first), a single PlutusV4 ref-script aborts the whole restore. This PR closes the structural gap so downstream callers can construct `Script.PlutusV4(bs)` as soon as their fixtures start carrying Dijkstra V4 entries.

## Test plan
- [x] `scalusJVM/Test/compile` — clean.
- [x] `scalusCardanoLedgerJVM/Test/compile` — clean (no non-exhaustive-match warnings).
- [x] Added `Pretty[Script] PlutusV4` case mirroring the `PlutusV3` test.
- [x] `Arbitrary[Script]` now generates V4; existing property tests over `Script` exercise the new case automatically.
- [ ] Full project test suite — not run locally (nix toolchain not available); please rely on CI.

## Out of scope
- Plutus VM V4 evaluation semantics (upstream `plutus-core`).
- CDDL-level `plutusV4Scripts` witness-set field + on-chain wire format — paired CDDL update will land separately.
- Dijkstra-era cost-model parameters.