### PR TITLE
refactor(ledger): move ConwayProtocolParams from test to main

### DIFF
--- a/scalus-cardano-ledger-it/src/test/scala/scalus/testing/conformance/ScriptContextComparisonTest.scala
+++ b/scalus-cardano-ledger-it/src/test/scala/scalus/testing/conformance/ScriptContextComparisonTest.scala
@@ -51,11 +51,11 @@ class ScriptContextComparisonTest extends AnyFunSuite with BeforeAndAfterEach {
 
             // Load protocol params - first try explicit pparamsHash, then fall back to searching
             val paramsOpt = vector.pparamsHash
-                .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 .orElse(
-                  ConwayProtocolParams
+                  ConwayProtocolParamsFixtures
                       .extractPparamsHash(vector.oldLedgerState, pparamsDir)
-                      .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                      .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 )
                 .map(_.toProtocolParams)
 
@@ -191,11 +191,11 @@ class ScriptContextComparisonTest extends AnyFunSuite with BeforeAndAfterEach {
             val utxos = state.utxos
 
             val paramsOpt = vector.pparamsHash
-                .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 .orElse(
-                  ConwayProtocolParams
+                  ConwayProtocolParamsFixtures
                       .extractPparamsHash(vector.oldLedgerState, pparamsDir)
-                      .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                      .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 )
                 .map(_.toProtocolParams)
 
@@ -269,11 +269,11 @@ class ScriptContextComparisonTest extends AnyFunSuite with BeforeAndAfterEach {
             val utxos = state.utxos
 
             val paramsOpt = vector.pparamsHash
-                .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 .orElse(
-                  ConwayProtocolParams
+                  ConwayProtocolParamsFixtures
                       .extractPparamsHash(vector.oldLedgerState, pparamsDir)
-                      .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                      .flatMap(hash => ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash))
                 )
                 .map(_.toProtocolParams)
 

--- a/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
+++ b/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
@@ -1,0 +1,323 @@
+package scalus.cardano.ledger
+
+import io.bullet.borer.*
+import io.bullet.borer.Dom.Element
+
+/** Conway protocol parameters as encoded by `cardano-ledger`'s `EncCBOR (PParams Conway)` instance
+  * — the same shape returned by the `LocalStateQuery` mini-protocol's `GetCurrentPParams` and the
+  * on-disk `pparams-by-hash` files used by conformance test vectors.
+  *
+  * Conway PParams is encoded as an array of 31 elements in this order (from `eraPParams` in
+  * `cardano-ledger/Conway/PParams.hs`):
+  *   - 0: minFeeA (Coin)
+  *   - 1: minFeeB (Coin)
+  *   - 2: maxBBSize (Word32)
+  *   - 3: maxTxSize (Word32)
+  *   - 4: maxBHSize (Word16)
+  *   - 5: keyDeposit (Coin)
+  *   - 6: poolDeposit (CompactForm Coin)
+  *   - 7: eMax (EpochInterval)
+  *   - 8: nOpt (Word16)
+  *   - 9: a0 (NonNegativeInterval)
+  *   - 10: rho (UnitInterval)
+  *   - 11: tau (UnitInterval)
+  *   - 12: protocolVersion (ProtVer)
+  *   - 13: minPoolCost (Coin)
+  *   - 14: coinsPerUTxOByte (CoinPerByte)
+  *   - 15: costModels (CostModels)
+  *   - 16: prices (Prices - [memPrice, stepPrice])
+  *   - 17: maxTxExUnits (ExUnits)
+  *   - 18: maxBlockExUnits (ExUnits)
+  *   - 19: maxValSize (Word32)
+  *   - 20: collateralPercentage (Word16)
+  *   - 21: maxCollateralInputs (Word16)
+  *   - 22: poolVotingThresholds
+  *   - 23: dRepVotingThresholds
+  *   - 24: committeeMinSize (Word16)
+  *   - 25: committeeMaxTermLength (EpochInterval)
+  *   - 26: govActionLifetime (EpochInterval)
+  *   - 27: govActionDeposit (Coin)
+  *   - 28: dRepDeposit (CompactForm Coin)
+  *   - 29: dRepActivity (EpochInterval)
+  *   - 30: minFeeRefScriptCostPerByte (NonNegativeInterval)
+  *
+  * `poolVotingThresholdsRaw` and `dRepVotingThresholdsRaw` are kept as raw `Dom.Element` because
+  * the typed CBOR codecs for `PoolVotingThresholds` / `DRepVotingThresholds` don't yet exist in
+  * scalus; [[toProtocolParams]] currently fills those typed fields from a Blockfrost-shaped
+  * fallback. Wire those decoders and the fallback drops out.
+  */
+case class ConwayProtocolParams(
+    minFeeA: Long,
+    minFeeB: Long,
+    maxBBSize: Long,
+    maxTxSize: Long,
+    maxBHSize: Long,
+    keyDeposit: Long, // stakeAddressDeposit
+    poolDeposit: Long,
+    eMax: Long,
+    nOpt: Long,
+    a0Numerator: Long, // pool pledge influence numerator
+    a0Denominator: Long,
+    rhoNumerator: Long, // monetary expansion numerator
+    rhoDenominator: Long,
+    tauNumerator: Long, // treasury cut numerator
+    tauDenominator: Long,
+    protocolVersionMajor: Long,
+    protocolVersionMinor: Long,
+    minPoolCost: Long,
+    coinsPerUTxOByte: Long,
+    costModelsRaw: Element, // CostModels as DOM element
+    pricesMemNumerator: Long,
+    pricesMemDenominator: Long,
+    pricesStepNumerator: Long,
+    pricesStepDenominator: Long,
+    maxTxExMem: Long,
+    maxTxExSteps: Long,
+    maxBlockExMem: Long,
+    maxBlockExSteps: Long,
+    maxValSize: Long,
+    collateralPercentage: Long,
+    maxCollateralInputs: Long,
+    poolVotingThresholdsRaw: Element,
+    dRepVotingThresholdsRaw: Element,
+    committeeMinSize: Long,
+    committeeMaxTermLength: Long,
+    govActionLifetime: Long,
+    govActionDeposit: Long,
+    dRepDeposit: Long,
+    dRepActivity: Long,
+    minFeeRefScriptCostPerByteNum: Long,
+    minFeeRefScriptCostPerByteDen: Long
+):
+    /** Parse cost models from raw DOM element. Returns None if parsing fails, allowing fallback to
+      * default cost models.
+      */
+    private def parseCostModels: Option[CostModels] =
+        try
+            costModelsRaw match
+                case mapElem: Dom.MapElem =>
+                    val models = mapElem.toMap.flatMap { case (key, value) =>
+                        val langIdOpt = key match
+                            case Dom.IntElem(v)  => Some(v)
+                            case Dom.LongElem(v) => Some(v.toInt)
+                            case _               => None
+                        val costsOpt = value match
+                            case arr: Dom.ArrayElem =>
+                                Some(
+                                  arr.elems.map {
+                                      case Dom.IntElem(v)  => v.toLong
+                                      case Dom.LongElem(v) => v
+                                      case _               => 0L
+                                  }.toIndexedSeq
+                                )
+                            case _ => None
+                        for langId <- langIdOpt; costs <- costsOpt yield langId -> costs
+                    }
+                    Some(CostModels(models))
+                case _ => None
+        catch case _: Exception => None
+
+    /** Convert to scalus's [[ProtocolParams]] type.
+      *
+      * Fields not covered by the Conway CBOR encoding (pool-voting / drep-voting thresholds — see
+      * class doc) come from a static Blockfrost-shaped baseline shipped with scalus-core
+      * (`/blockfrost-params-epoch-544.json`). Override-fields from the CBOR-decoded values replace
+      * the baseline.
+      */
+    def toProtocolParams: ProtocolParams =
+        val baseParams = ProtocolParams.fromBlockfrostJson(
+          this.getClass.getResourceAsStream("/blockfrost-params-epoch-544.json")
+        )
+        val costModels = parseCostModels.getOrElse(baseParams.costModels)
+        baseParams.copy(
+          txFeePerByte = minFeeA,
+          txFeeFixed = minFeeB,
+          maxBlockBodySize = maxBBSize,
+          maxTxSize = maxTxSize,
+          maxBlockHeaderSize = maxBHSize,
+          stakeAddressDeposit = keyDeposit,
+          stakePoolDeposit = poolDeposit,
+          poolRetireMaxEpoch = eMax,
+          stakePoolTargetNum = nOpt,
+          poolPledgeInfluence =
+              if a0Denominator == 0 then 0.0 else a0Numerator.toDouble / a0Denominator,
+          monetaryExpansion =
+              if rhoDenominator == 0 then 0.0 else rhoNumerator.toDouble / rhoDenominator,
+          treasuryCut = if tauDenominator == 0 then 0.0 else tauNumerator.toDouble / tauDenominator,
+          protocolVersion = ProtocolVersion(protocolVersionMajor.toInt, protocolVersionMinor.toInt),
+          minPoolCost = minPoolCost,
+          utxoCostPerByte = coinsPerUTxOByte,
+          costModels = costModels,
+          executionUnitPrices = ExUnitPrices(
+            priceMemory = NonNegativeInterval(
+              if pricesMemDenominator == 0 then 0.0
+              else pricesMemNumerator.toDouble / pricesMemDenominator
+            ),
+            priceSteps = NonNegativeInterval(
+              if pricesStepDenominator == 0 then 0.0
+              else pricesStepNumerator.toDouble / pricesStepDenominator
+            )
+          ),
+          maxTxExecutionUnits = ExUnits(maxTxExMem, maxTxExSteps),
+          maxBlockExecutionUnits = ExUnits(maxBlockExMem, maxBlockExSteps),
+          maxValueSize = maxValSize,
+          collateralPercentage = collateralPercentage,
+          maxCollateralInputs = maxCollateralInputs,
+          committeeMinSize = committeeMinSize,
+          committeeMaxTermLength = committeeMaxTermLength,
+          govActionLifetime = govActionLifetime,
+          govActionDeposit = govActionDeposit,
+          dRepDeposit = dRepDeposit,
+          dRepActivity = dRepActivity,
+          minFeeRefScriptCostPerByte =
+              if minFeeRefScriptCostPerByteDen == 0 then 0L
+              else minFeeRefScriptCostPerByteNum / minFeeRefScriptCostPerByteDen
+        )
+
+object ConwayProtocolParams:
+    def fromCbor(cbor: Array[Byte]): ConwayProtocolParams =
+        Cbor.decode(cbor).to[ConwayProtocolParams].value
+
+    given Decoder[ConwayProtocolParams] with
+        def read(r: Reader): ConwayProtocolParams =
+            val size = r.readArrayHeader()
+            // Can be 31 (without minFeeRefScriptCostPerByte) or 31+ with it
+            require(size >= 31, s"Expected at least 31 elements, got $size")
+
+            val minFeeA = r.readLong()
+            val minFeeB = r.readLong()
+            val maxBBSize = r.readLong()
+            val maxTxSize = r.readLong()
+            val maxBHSize = r.readLong()
+            val keyDeposit = r.readLong()
+            val poolDeposit = r.readLong()
+            val eMax = r.readLong()
+            val nOpt = r.readLong()
+
+            // a0 = NonNegativeInterval = Tagged(30, [num, denom])
+            val a0Tag = r.read[Dom.Element]()
+            val (a0Num, a0Denom) = parseTaggedRational(a0Tag)
+
+            // rho = UnitInterval = Tagged(30, [num, denom])
+            val rhoTag = r.read[Dom.Element]()
+            val (rhoNum, rhoDenom) = parseTaggedRational(rhoTag)
+
+            // tau = UnitInterval = Tagged(30, [num, denom])
+            val tauTag = r.read[Dom.Element]()
+            val (tauNum, tauDenom) = parseTaggedRational(tauTag)
+
+            // protocolVersion = [major, minor]
+            r.readArrayHeader(2)
+            val pvMajor = r.readLong()
+            val pvMinor = r.readLong()
+
+            val minPoolCost = r.readLong()
+            val coinsPerUTxOByte = r.readLong()
+
+            // costModels - keep as DOM element
+            val costModels = r.read[Dom.Element]()
+
+            // prices = [memPrice, stepPrice] where each is Tagged(30, [num, denom])
+            r.readArrayHeader(2)
+            val memPriceTag = r.read[Dom.Element]()
+            val (memPriceNum, memPriceDenom) = parseTaggedRational(memPriceTag)
+            val stepPriceTag = r.read[Dom.Element]()
+            val (stepPriceNum, stepPriceDenom) = parseTaggedRational(stepPriceTag)
+
+            // maxTxExUnits = [mem, steps]
+            r.readArrayHeader(2)
+            val maxTxExMem = r.readLong()
+            val maxTxExSteps = r.readLong()
+
+            // maxBlockExUnits = [mem, steps]
+            r.readArrayHeader(2)
+            val maxBlockExMem = r.readLong()
+            val maxBlockExSteps = r.readLong()
+
+            val maxValSize = r.readLong()
+            val collateralPercentage = r.readLong()
+            val maxCollateralInputs = r.readLong()
+
+            // poolVotingThresholds - keep as DOM
+            val poolVotingThresholds = r.read[Dom.Element]()
+
+            // dRepVotingThresholds - keep as DOM
+            val dRepVotingThresholds = r.read[Dom.Element]()
+
+            val committeeMinSize = r.readLong()
+            val committeeMaxTermLength = r.readLong()
+            val govActionLifetime = r.readLong()
+            val govActionDeposit = r.readLong()
+            val dRepDeposit = r.readLong()
+            val dRepActivity = r.readLong()
+
+            val (refScriptNum, refScriptDenom) =
+                if size > 30 then
+                    val tag = r.read[Dom.Element]()
+                    parseTaggedRational(tag)
+                else (0L, 1L)
+
+            ConwayProtocolParams(
+              minFeeA = minFeeA,
+              minFeeB = minFeeB,
+              maxBBSize = maxBBSize,
+              maxTxSize = maxTxSize,
+              maxBHSize = maxBHSize,
+              keyDeposit = keyDeposit,
+              poolDeposit = poolDeposit,
+              eMax = eMax,
+              nOpt = nOpt,
+              a0Numerator = a0Num,
+              a0Denominator = a0Denom,
+              rhoNumerator = rhoNum,
+              rhoDenominator = rhoDenom,
+              tauNumerator = tauNum,
+              tauDenominator = tauDenom,
+              protocolVersionMajor = pvMajor,
+              protocolVersionMinor = pvMinor,
+              minPoolCost = minPoolCost,
+              coinsPerUTxOByte = coinsPerUTxOByte,
+              costModelsRaw = costModels,
+              pricesMemNumerator = memPriceNum,
+              pricesMemDenominator = memPriceDenom,
+              pricesStepNumerator = stepPriceNum,
+              pricesStepDenominator = stepPriceDenom,
+              maxTxExMem = maxTxExMem,
+              maxTxExSteps = maxTxExSteps,
+              maxBlockExMem = maxBlockExMem,
+              maxBlockExSteps = maxBlockExSteps,
+              maxValSize = maxValSize,
+              collateralPercentage = collateralPercentage,
+              maxCollateralInputs = maxCollateralInputs,
+              poolVotingThresholdsRaw = poolVotingThresholds,
+              dRepVotingThresholdsRaw = dRepVotingThresholds,
+              committeeMinSize = committeeMinSize,
+              committeeMaxTermLength = committeeMaxTermLength,
+              govActionLifetime = govActionLifetime,
+              govActionDeposit = govActionDeposit,
+              dRepDeposit = dRepDeposit,
+              dRepActivity = dRepActivity,
+              minFeeRefScriptCostPerByteNum = refScriptNum,
+              minFeeRefScriptCostPerByteDen = refScriptDenom
+            )
+
+    private def parseTaggedRational(elem: Dom.Element): (Long, Long) =
+        elem match
+            case tagged: Dom.TaggedElem if tagged.tag.code == 30 =>
+                tagged.value match
+                    case arr: Dom.ArrayElem if arr.elems.size == 2 =>
+                        val num = extractLong(arr.elems(0))
+                        val denom = extractLong(arr.elems(1))
+                        (num, denom)
+                    case other =>
+                        throw new RuntimeException(
+                          s"Expected array of 2 elements in Tagged(30), got $other"
+                        )
+            case other =>
+                throw new RuntimeException(s"Expected Tagged(30, [num, denom]), got $other")
+
+    private def extractLong(elem: Dom.Element): Long =
+        elem match
+            case Dom.IntElem(v)  => v.toLong
+            case Dom.LongElem(v) => v
+            case other           => throw new RuntimeException(s"Expected integer, got $other")

--- a/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
+++ b/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
@@ -1,7 +1,8 @@
 package scalus.cardano.ledger
 
 import io.bullet.borer.*
-import io.bullet.borer.Dom.Element
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 /** Conway protocol parameters as encoded by `cardano-ledger`'s `EncCBOR (PParams Conway)` instance
   * — the same shape returned by the `LocalStateQuery` mini-protocol's `GetCurrentPParams` and the
@@ -41,10 +42,8 @@ import io.bullet.borer.Dom.Element
   *   - 29: dRepActivity (EpochInterval)
   *   - 30: minFeeRefScriptCostPerByte (NonNegativeInterval)
   *
-  * `poolVotingThresholdsRaw` and `dRepVotingThresholdsRaw` are kept as raw `Dom.Element` because
-  * the typed CBOR codecs for `PoolVotingThresholds` / `DRepVotingThresholds` don't yet exist in
-  * scalus; [[toProtocolParams]] currently fills those typed fields from a Blockfrost-shaped
-  * fallback. Wire those decoders and the fallback drops out.
+  * Arrays larger than 31 elements are tolerated for forward-compatibility with future era
+  * extensions: trailing entries are read and discarded with a single warn-level log.
   */
 case class ConwayProtocolParams(
     minFeeA: Long,
@@ -52,137 +51,86 @@ case class ConwayProtocolParams(
     maxBBSize: Long,
     maxTxSize: Long,
     maxBHSize: Long,
-    keyDeposit: Long, // stakeAddressDeposit
+    keyDeposit: Long,
     poolDeposit: Long,
     eMax: Long,
     nOpt: Long,
-    a0Numerator: Long, // pool pledge influence numerator
-    a0Denominator: Long,
-    rhoNumerator: Long, // monetary expansion numerator
-    rhoDenominator: Long,
-    tauNumerator: Long, // treasury cut numerator
-    tauDenominator: Long,
-    protocolVersionMajor: Long,
-    protocolVersionMinor: Long,
+    a0: NonNegativeInterval,
+    rho: UnitInterval,
+    tau: UnitInterval,
+    protocolVersion: ProtocolVersion,
     minPoolCost: Long,
     coinsPerUTxOByte: Long,
-    costModelsRaw: Element, // CostModels as DOM element
-    pricesMemNumerator: Long,
-    pricesMemDenominator: Long,
-    pricesStepNumerator: Long,
-    pricesStepDenominator: Long,
-    maxTxExMem: Long,
-    maxTxExSteps: Long,
-    maxBlockExMem: Long,
-    maxBlockExSteps: Long,
+    costModels: CostModels,
+    prices: ExUnitPrices,
+    maxTxExUnits: ExUnits,
+    maxBlockExUnits: ExUnits,
     maxValSize: Long,
     collateralPercentage: Long,
     maxCollateralInputs: Long,
-    poolVotingThresholdsRaw: Element,
-    dRepVotingThresholdsRaw: Element,
+    poolVotingThresholds: PoolVotingThresholds,
+    dRepVotingThresholds: DRepVotingThresholds,
     committeeMinSize: Long,
     committeeMaxTermLength: Long,
     govActionLifetime: Long,
     govActionDeposit: Long,
     dRepDeposit: Long,
     dRepActivity: Long,
-    minFeeRefScriptCostPerByteNum: Long,
-    minFeeRefScriptCostPerByteDen: Long
+    minFeeRefScriptCostPerByte: NonNegativeInterval
 ):
-    /** Parse cost models from raw DOM element. Returns None if parsing fails, allowing fallback to
-      * default cost models.
-      */
-    private def parseCostModels: Option[CostModels] =
-        try
-            costModelsRaw match
-                case mapElem: Dom.MapElem =>
-                    val models = mapElem.toMap.flatMap { case (key, value) =>
-                        val langIdOpt = key match
-                            case Dom.IntElem(v)  => Some(v)
-                            case Dom.LongElem(v) => Some(v.toInt)
-                            case _               => None
-                        val costsOpt = value match
-                            case arr: Dom.ArrayElem =>
-                                Some(
-                                  arr.elems.map {
-                                      case Dom.IntElem(v)  => v.toLong
-                                      case Dom.LongElem(v) => v
-                                      case _               => 0L
-                                  }.toIndexedSeq
-                                )
-                            case _ => None
-                        for langId <- langIdOpt; costs <- costsOpt yield langId -> costs
-                    }
-                    Some(CostModels(models))
-                case _ => None
-        catch case _: Exception => None
-
-    /** Convert to scalus's [[ProtocolParams]] type.
-      *
-      * Fields not covered by the Conway CBOR encoding (pool-voting / drep-voting thresholds — see
-      * class doc) come from a static Blockfrost-shaped baseline shipped with scalus-core
-      * (`/blockfrost-params-epoch-544.json`). Override-fields from the CBOR-decoded values replace
-      * the baseline.
+    /** Convert to scalus's [[ProtocolParams]] type. All fields come from the decoded CBOR; no
+      * external baseline is consulted.
       */
     def toProtocolParams: ProtocolParams =
-        val baseParams = ProtocolParams.fromBlockfrostJson(
-          this.getClass.getResourceAsStream("/blockfrost-params-epoch-544.json")
-        )
-        val costModels = parseCostModels.getOrElse(baseParams.costModels)
-        baseParams.copy(
-          txFeePerByte = minFeeA,
-          txFeeFixed = minFeeB,
+        ProtocolParams(
+          collateralPercentage = collateralPercentage,
+          committeeMaxTermLength = committeeMaxTermLength,
+          committeeMinSize = committeeMinSize,
+          costModels = costModels,
+          dRepActivity = dRepActivity,
+          dRepDeposit = dRepDeposit,
+          dRepVotingThresholds = dRepVotingThresholds,
+          executionUnitPrices = prices,
+          govActionDeposit = govActionDeposit,
+          govActionLifetime = govActionLifetime,
           maxBlockBodySize = maxBBSize,
-          maxTxSize = maxTxSize,
+          maxBlockExecutionUnits = maxBlockExUnits,
           maxBlockHeaderSize = maxBHSize,
+          maxCollateralInputs = maxCollateralInputs,
+          maxTxExecutionUnits = maxTxExUnits,
+          maxTxSize = maxTxSize,
+          maxValueSize = maxValSize,
+          minFeeRefScriptCostPerByte = minFeeRefScriptCostPerByte.floor,
+          minPoolCost = minPoolCost,
+          monetaryExpansion = rho.toDouble,
+          poolPledgeInfluence = a0.toDouble,
+          poolRetireMaxEpoch = eMax,
+          poolVotingThresholds = poolVotingThresholds,
+          protocolVersion = protocolVersion,
           stakeAddressDeposit = keyDeposit,
           stakePoolDeposit = poolDeposit,
-          poolRetireMaxEpoch = eMax,
           stakePoolTargetNum = nOpt,
-          poolPledgeInfluence =
-              if a0Denominator == 0 then 0.0 else a0Numerator.toDouble / a0Denominator,
-          monetaryExpansion =
-              if rhoDenominator == 0 then 0.0 else rhoNumerator.toDouble / rhoDenominator,
-          treasuryCut = if tauDenominator == 0 then 0.0 else tauNumerator.toDouble / tauDenominator,
-          protocolVersion = ProtocolVersion(protocolVersionMajor.toInt, protocolVersionMinor.toInt),
-          minPoolCost = minPoolCost,
-          utxoCostPerByte = coinsPerUTxOByte,
-          costModels = costModels,
-          executionUnitPrices = ExUnitPrices(
-            priceMemory = NonNegativeInterval(
-              if pricesMemDenominator == 0 then 0.0
-              else pricesMemNumerator.toDouble / pricesMemDenominator
-            ),
-            priceSteps = NonNegativeInterval(
-              if pricesStepDenominator == 0 then 0.0
-              else pricesStepNumerator.toDouble / pricesStepDenominator
-            )
-          ),
-          maxTxExecutionUnits = ExUnits(maxTxExMem, maxTxExSteps),
-          maxBlockExecutionUnits = ExUnits(maxBlockExMem, maxBlockExSteps),
-          maxValueSize = maxValSize,
-          collateralPercentage = collateralPercentage,
-          maxCollateralInputs = maxCollateralInputs,
-          committeeMinSize = committeeMinSize,
-          committeeMaxTermLength = committeeMaxTermLength,
-          govActionLifetime = govActionLifetime,
-          govActionDeposit = govActionDeposit,
-          dRepDeposit = dRepDeposit,
-          dRepActivity = dRepActivity,
-          minFeeRefScriptCostPerByte =
-              if minFeeRefScriptCostPerByteDen == 0 then 0L
-              else minFeeRefScriptCostPerByteNum / minFeeRefScriptCostPerByteDen
+          treasuryCut = tau.toDouble,
+          txFeeFixed = minFeeB,
+          txFeePerByte = minFeeA,
+          utxoCostPerByte = coinsPerUTxOByte
         )
 
 object ConwayProtocolParams:
+    private val ConwayPParamsArity = 31
+    private val log = scribe.Logger[ConwayProtocolParams.type]
+    private val warnedOnExtras = new AtomicBoolean(false)
+
     def fromCbor(cbor: Array[Byte]): ConwayProtocolParams =
         Cbor.decode(cbor).to[ConwayProtocolParams].value
 
     given Decoder[ConwayProtocolParams] with
         def read(r: Reader): ConwayProtocolParams =
             val size = r.readArrayHeader()
-            // Can be 31 (without minFeeRefScriptCostPerByte) or 31+ with it
-            require(size >= 31, s"Expected at least 31 elements, got $size")
+            require(
+              size >= ConwayPParamsArity,
+              s"Expected at least $ConwayPParamsArity elements, got $size"
+            )
 
             val minFeeA = r.readLong()
             val minFeeB = r.readLong()
@@ -194,55 +142,25 @@ object ConwayProtocolParams:
             val eMax = r.readLong()
             val nOpt = r.readLong()
 
-            // a0 = NonNegativeInterval = Tagged(30, [num, denom])
-            val a0Tag = r.read[Dom.Element]()
-            val (a0Num, a0Denom) = parseTaggedRational(a0Tag)
-
-            // rho = UnitInterval = Tagged(30, [num, denom])
-            val rhoTag = r.read[Dom.Element]()
-            val (rhoNum, rhoDenom) = parseTaggedRational(rhoTag)
-
-            // tau = UnitInterval = Tagged(30, [num, denom])
-            val tauTag = r.read[Dom.Element]()
-            val (tauNum, tauDenom) = parseTaggedRational(tauTag)
-
-            // protocolVersion = [major, minor]
-            r.readArrayHeader(2)
-            val pvMajor = r.readLong()
-            val pvMinor = r.readLong()
+            val a0 = r.read[NonNegativeInterval]()
+            val rho = r.read[UnitInterval]()
+            val tau = r.read[UnitInterval]()
+            val protocolVersion = r.read[ProtocolVersion]()
 
             val minPoolCost = r.readLong()
             val coinsPerUTxOByte = r.readLong()
 
-            // costModels - keep as DOM element
-            val costModels = r.read[Dom.Element]()
-
-            // prices = [memPrice, stepPrice] where each is Tagged(30, [num, denom])
-            r.readArrayHeader(2)
-            val memPriceTag = r.read[Dom.Element]()
-            val (memPriceNum, memPriceDenom) = parseTaggedRational(memPriceTag)
-            val stepPriceTag = r.read[Dom.Element]()
-            val (stepPriceNum, stepPriceDenom) = parseTaggedRational(stepPriceTag)
-
-            // maxTxExUnits = [mem, steps]
-            r.readArrayHeader(2)
-            val maxTxExMem = r.readLong()
-            val maxTxExSteps = r.readLong()
-
-            // maxBlockExUnits = [mem, steps]
-            r.readArrayHeader(2)
-            val maxBlockExMem = r.readLong()
-            val maxBlockExSteps = r.readLong()
+            val costModels = r.read[CostModels]()
+            val prices = r.read[ExUnitPrices]()
+            val maxTxExUnits = r.read[ExUnits]()
+            val maxBlockExUnits = r.read[ExUnits]()
 
             val maxValSize = r.readLong()
             val collateralPercentage = r.readLong()
             val maxCollateralInputs = r.readLong()
 
-            // poolVotingThresholds - keep as DOM
-            val poolVotingThresholds = r.read[Dom.Element]()
-
-            // dRepVotingThresholds - keep as DOM
-            val dRepVotingThresholds = r.read[Dom.Element]()
+            val poolVotingThresholds = r.read[PoolVotingThresholds]()
+            val dRepVotingThresholds = r.read[DRepVotingThresholds]()
 
             val committeeMinSize = r.readLong()
             val committeeMaxTermLength = r.readLong()
@@ -251,11 +169,16 @@ object ConwayProtocolParams:
             val dRepDeposit = r.readLong()
             val dRepActivity = r.readLong()
 
-            val (refScriptNum, refScriptDenom) =
-                if size > 30 then
-                    val tag = r.read[Dom.Element]()
-                    parseTaggedRational(tag)
-                else (0L, 1L)
+            val minFeeRefScriptCostPerByte = r.read[NonNegativeInterval]()
+
+            val extras = size - ConwayPParamsArity
+            if extras > 0 then
+                if warnedOnExtras.compareAndSet(false, true) then
+                    log.warn(
+                      s"Conway PParams CBOR has $size fields; expected $ConwayPParamsArity. " +
+                          s"Skipping $extras unknown trailing field(s) — schema may have advanced."
+                    )
+                (0 until extras.toInt).foreach(_ => r.skipElement())
 
             ConwayProtocolParams(
               minFeeA = minFeeA,
@@ -267,57 +190,26 @@ object ConwayProtocolParams:
               poolDeposit = poolDeposit,
               eMax = eMax,
               nOpt = nOpt,
-              a0Numerator = a0Num,
-              a0Denominator = a0Denom,
-              rhoNumerator = rhoNum,
-              rhoDenominator = rhoDenom,
-              tauNumerator = tauNum,
-              tauDenominator = tauDenom,
-              protocolVersionMajor = pvMajor,
-              protocolVersionMinor = pvMinor,
+              a0 = a0,
+              rho = rho,
+              tau = tau,
+              protocolVersion = protocolVersion,
               minPoolCost = minPoolCost,
               coinsPerUTxOByte = coinsPerUTxOByte,
-              costModelsRaw = costModels,
-              pricesMemNumerator = memPriceNum,
-              pricesMemDenominator = memPriceDenom,
-              pricesStepNumerator = stepPriceNum,
-              pricesStepDenominator = stepPriceDenom,
-              maxTxExMem = maxTxExMem,
-              maxTxExSteps = maxTxExSteps,
-              maxBlockExMem = maxBlockExMem,
-              maxBlockExSteps = maxBlockExSteps,
+              costModels = costModels,
+              prices = prices,
+              maxTxExUnits = maxTxExUnits,
+              maxBlockExUnits = maxBlockExUnits,
               maxValSize = maxValSize,
               collateralPercentage = collateralPercentage,
               maxCollateralInputs = maxCollateralInputs,
-              poolVotingThresholdsRaw = poolVotingThresholds,
-              dRepVotingThresholdsRaw = dRepVotingThresholds,
+              poolVotingThresholds = poolVotingThresholds,
+              dRepVotingThresholds = dRepVotingThresholds,
               committeeMinSize = committeeMinSize,
               committeeMaxTermLength = committeeMaxTermLength,
               govActionLifetime = govActionLifetime,
               govActionDeposit = govActionDeposit,
               dRepDeposit = dRepDeposit,
               dRepActivity = dRepActivity,
-              minFeeRefScriptCostPerByteNum = refScriptNum,
-              minFeeRefScriptCostPerByteDen = refScriptDenom
+              minFeeRefScriptCostPerByte = minFeeRefScriptCostPerByte
             )
-
-    private def parseTaggedRational(elem: Dom.Element): (Long, Long) =
-        elem match
-            case tagged: Dom.TaggedElem if tagged.tag.code == 30 =>
-                tagged.value match
-                    case arr: Dom.ArrayElem if arr.elems.size == 2 =>
-                        val num = extractLong(arr.elems(0))
-                        val denom = extractLong(arr.elems(1))
-                        (num, denom)
-                    case other =>
-                        throw new RuntimeException(
-                          s"Expected array of 2 elements in Tagged(30), got $other"
-                        )
-            case other =>
-                throw new RuntimeException(s"Expected Tagged(30, [num, denom]), got $other")
-
-    private def extractLong(elem: Dom.Element): Long =
-        elem match
-            case Dom.IntElem(v)  => v.toLong
-            case Dom.LongElem(v) => v
-            case other           => throw new RuntimeException(s"Expected integer, got $other")

--- a/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
+++ b/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/ledger/ConwayProtocolParams.scala
@@ -127,10 +127,10 @@ object ConwayProtocolParams:
     given Decoder[ConwayProtocolParams] with
         def read(r: Reader): ConwayProtocolParams =
             val size = r.readArrayHeader()
-            require(
-              size >= ConwayPParamsArity,
-              s"Expected at least $ConwayPParamsArity elements, got $size"
-            )
+            if size < ConwayPParamsArity then
+                r.validationFailure(
+                  s"Expected at least $ConwayPParamsArity elements for Conway PParams, got $size"
+                )
 
             val minFeeA = r.readLong()
             val minFeeB = r.readLong()

--- a/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/CardanoLedgerVectors.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/CardanoLedgerVectors.scala
@@ -43,11 +43,15 @@ object CardanoLedgerVectors {
             val params =
                 if useParams then
                     vector.pparamsHash
-                        .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                        .flatMap(hash =>
+                            ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash)
+                        )
                         .orElse(
-                          ConwayProtocolParams
+                          ConwayProtocolParamsFixtures
                               .extractPparamsHash(vector.oldLedgerState, pparamsDir)
-                              .flatMap(hash => ConwayProtocolParams.loadFromHash(pparamsDir, hash))
+                              .flatMap(hash =>
+                                  ConwayProtocolParamsFixtures.loadFromHash(pparamsDir, hash)
+                              )
                         )
                         .map(_.toProtocolParams)
                 else None

--- a/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/LedgerState.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/LedgerState.scala
@@ -623,7 +623,7 @@ object ConwayProtocolParamsFixtures:
         if matchingHashes.size == 1 then return Some(matchingHashes.head)
 
         val hashesWithVersion = matchingHashes.flatMap { hash =>
-            loadFromHash(pparamsDir, hash).map(pp => (hash, pp.protocolVersionMajor))
+            loadFromHash(pparamsDir, hash).map(pp => (hash, pp.protocolVersion.major))
         }
 
         hashesWithVersion

--- a/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/LedgerState.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/scalus/testing/conformance/LedgerState.scala
@@ -581,177 +581,23 @@ object LedgerState {
 
 }
 
-/** Conway protocol parameters from cardano-ledger test vectors.
-  *
-  * Conway PParams is encoded as an array of 31 elements in this order (from eraPParams in
-  * Conway/PParams.hs):
-  *   - 0: minFeeA (Coin)
-  *   - 1: minFeeB (Coin)
-  *   - 2: maxBBSize (Word32)
-  *   - 3: maxTxSize (Word32)
-  *   - 4: maxBHSize (Word16)
-  *   - 5: keyDeposit (Coin)
-  *   - 6: poolDeposit (CompactForm Coin)
-  *   - 7: eMax (EpochInterval)
-  *   - 8: nOpt (Word16)
-  *   - 9: a0 (NonNegativeInterval)
-  *   - 10: rho (UnitInterval)
-  *   - 11: tau (UnitInterval)
-  *   - 12: protocolVersion (ProtVer)
-  *   - 13: minPoolCost (Coin)
-  *   - 14: coinsPerUTxOByte (CoinPerByte)
-  *   - 15: costModels (CostModels)
-  *   - 16: prices (Prices - [memPrice, stepPrice])
-  *   - 17: maxTxExUnits (ExUnits)
-  *   - 18: maxBlockExUnits (ExUnits)
-  *   - 19: maxValSize (Word32)
-  *   - 20: collateralPercentage (Word16)
-  *   - 21: maxCollateralInputs (Word16)
-  *   - 22: poolVotingThresholds
-  *   - 23: dRepVotingThresholds
-  *   - 24: committeeMinSize (Word16)
-  *   - 25: committeeMaxTermLength (EpochInterval)
-  *   - 26: govActionLifetime (EpochInterval)
-  *   - 27: govActionDeposit (Coin)
-  *   - 28: dRepDeposit (CompactForm Coin)
-  *   - 29: dRepActivity (EpochInterval)
-  *   - 30: minFeeRefScriptCostPerByte (NonNegativeInterval)
+// Conway PParams (case class + Decoder + toProtocolParams + fromCbor) lives in
+// scalus.cardano.ledger.ConwayProtocolParams — needed by production callers (e.g. the
+// LocalStateQuery N2C path in scalus-node) for `GetCurrentPParams`. The conformance-test
+// fixture helpers below depend on it but stay in test code because they index a directory
+// of test vectors keyed by hash.
+
+/** Test-fixture helpers for loading [[ConwayProtocolParams]] from the on-disk `pparams-by-hash`
+  * directory used by cardano-ledger conformance test vectors.
   */
-case class ConwayProtocolParams(
-    minFeeA: Long,
-    minFeeB: Long,
-    maxBBSize: Long,
-    maxTxSize: Long,
-    maxBHSize: Long,
-    keyDeposit: Long, // stakeAddressDeposit
-    poolDeposit: Long,
-    eMax: Long,
-    nOpt: Long,
-    a0Numerator: Long, // pool pledge influence numerator
-    a0Denominator: Long,
-    rhoNumerator: Long, // monetary expansion numerator
-    rhoDenominator: Long,
-    tauNumerator: Long, // treasury cut numerator
-    tauDenominator: Long,
-    protocolVersionMajor: Long,
-    protocolVersionMinor: Long,
-    minPoolCost: Long,
-    coinsPerUTxOByte: Long,
-    costModelsRaw: Element, // CostModels as DOM element
-    pricesMemNumerator: Long,
-    pricesMemDenominator: Long,
-    pricesStepNumerator: Long,
-    pricesStepDenominator: Long,
-    maxTxExMem: Long,
-    maxTxExSteps: Long,
-    maxBlockExMem: Long,
-    maxBlockExSteps: Long,
-    maxValSize: Long,
-    collateralPercentage: Long,
-    maxCollateralInputs: Long,
-    poolVotingThresholdsRaw: Element,
-    dRepVotingThresholdsRaw: Element,
-    committeeMinSize: Long,
-    committeeMaxTermLength: Long,
-    govActionLifetime: Long,
-    govActionDeposit: Long,
-    dRepDeposit: Long,
-    dRepActivity: Long,
-    minFeeRefScriptCostPerByteNum: Long,
-    minFeeRefScriptCostPerByteDen: Long
-):
-    /** Parse cost models from raw DOM element. Returns None if parsing fails, allowing fallback to
-      * default cost models.
-      */
-    private def parseCostModels: Option[CostModels] =
-        try
-            costModelsRaw match
-                case mapElem: Dom.MapElem =>
-                    val models = mapElem.toMap.flatMap { case (key, value) =>
-                        val langIdOpt = key match
-                            case Dom.IntElem(v)  => Some(v)
-                            case Dom.LongElem(v) => Some(v.toInt)
-                            case _               => None
-                        val costsOpt = value match
-                            case arr: Dom.ArrayElem =>
-                                Some(
-                                  arr.elems.map {
-                                      case Dom.IntElem(v)  => v.toLong
-                                      case Dom.LongElem(v) => v
-                                      case _               => 0L
-                                  }.toIndexedSeq
-                                )
-                            case _ => None
-                        for langId <- langIdOpt; costs <- costsOpt yield langId -> costs
-                    }
-                    Some(CostModels(models))
-                case _ => None
-        catch case _: Exception => None
-
-    /** Convert to Scalus ProtocolParams */
-    def toProtocolParams: ProtocolParams =
-        // Use default params as fallback for fields not in CBOR
-        val baseParams = ProtocolParams.fromBlockfrostJson(
-          this.getClass.getResourceAsStream("/blockfrost-params-epoch-544.json")
-        )
-        // Parse cost models from the test vectors (important for script data hash validation)
-        // Fall back to blockfrost params if parsing fails
-        val costModels = parseCostModels.getOrElse(baseParams.costModels)
-        baseParams.copy(
-          txFeePerByte = minFeeA,
-          txFeeFixed = minFeeB,
-          maxBlockBodySize = maxBBSize,
-          maxTxSize = maxTxSize,
-          maxBlockHeaderSize = maxBHSize,
-          stakeAddressDeposit = keyDeposit,
-          stakePoolDeposit = poolDeposit,
-          poolRetireMaxEpoch = eMax,
-          stakePoolTargetNum = nOpt,
-          poolPledgeInfluence =
-              if a0Denominator == 0 then 0.0 else a0Numerator.toDouble / a0Denominator,
-          monetaryExpansion =
-              if rhoDenominator == 0 then 0.0 else rhoNumerator.toDouble / rhoDenominator,
-          treasuryCut = if tauDenominator == 0 then 0.0 else tauNumerator.toDouble / tauDenominator,
-          protocolVersion = ProtocolVersion(protocolVersionMajor.toInt, protocolVersionMinor.toInt),
-          minPoolCost = minPoolCost,
-          utxoCostPerByte = coinsPerUTxOByte,
-          costModels = costModels,
-          executionUnitPrices = ExUnitPrices(
-            priceMemory = NonNegativeInterval(
-              if pricesMemDenominator == 0 then 0.0
-              else pricesMemNumerator.toDouble / pricesMemDenominator
-            ),
-            priceSteps = NonNegativeInterval(
-              if pricesStepDenominator == 0 then 0.0
-              else pricesStepNumerator.toDouble / pricesStepDenominator
-            )
-          ),
-          maxTxExecutionUnits = ExUnits(maxTxExMem, maxTxExSteps),
-          maxBlockExecutionUnits = ExUnits(maxBlockExMem, maxBlockExSteps),
-          maxValueSize = maxValSize,
-          collateralPercentage = collateralPercentage,
-          maxCollateralInputs = maxCollateralInputs,
-          committeeMinSize = committeeMinSize,
-          committeeMaxTermLength = committeeMaxTermLength,
-          govActionLifetime = govActionLifetime,
-          govActionDeposit = govActionDeposit,
-          dRepDeposit = dRepDeposit,
-          dRepActivity = dRepActivity,
-          minFeeRefScriptCostPerByte =
-              if minFeeRefScriptCostPerByteDen == 0 then 0L
-              else minFeeRefScriptCostPerByteNum / minFeeRefScriptCostPerByteDen
-        )
-
-object ConwayProtocolParams:
-    def fromCbor(cbor: Array[Byte]): ConwayProtocolParams =
-        Cbor.decode(cbor).to[ConwayProtocolParams].value
+object ConwayProtocolParamsFixtures:
 
     /** Load protocol params from pparams-by-hash directory using hash found in ledger state */
     def loadFromHash(pparamsDir: Path, hash: String): Option[ConwayProtocolParams] =
         val pparamsFile = pparamsDir.resolve(hash)
         if Files.exists(pparamsFile) then
             val cbor = Files.readAllBytes(pparamsFile)
-            Some(fromCbor(cbor))
+            Some(ConwayProtocolParams.fromCbor(cbor))
         else None
 
     /** Extract pparams hash from ledger state CBOR hex string.
@@ -765,7 +611,6 @@ object ConwayProtocolParams:
         import scala.jdk.CollectionConverters.*
         if !Files.exists(pparamsDir) then return None
 
-        // Find all pparams hashes that appear in the ledger state
         val matchingHashes = Files
             .list(pparamsDir)
             .iterator()
@@ -777,158 +622,11 @@ object ConwayProtocolParams:
         if matchingHashes.isEmpty then return None
         if matchingHashes.size == 1 then return Some(matchingHashes.head)
 
-        // If multiple matches, load each and pick the one with highest protocol version
         val hashesWithVersion = matchingHashes.flatMap { hash =>
             loadFromHash(pparamsDir, hash).map(pp => (hash, pp.protocolVersionMajor))
         }
 
         hashesWithVersion
-            .sortBy(-_._2) // Sort by protocol version descending
+            .sortBy(-_._2)
             .headOption
             .map(_._1)
-
-    given Decoder[ConwayProtocolParams] with
-        def read(r: Reader): ConwayProtocolParams =
-            val size = r.readArrayHeader()
-            // Can be 31 (without minFeeRefScriptCostPerByte) or 31+ with it
-            require(size >= 31, s"Expected at least 31 elements, got $size")
-
-            // Read each field in order
-            val minFeeA = r.readLong()
-            val minFeeB = r.readLong()
-            val maxBBSize = r.readLong()
-            val maxTxSize = r.readLong()
-            val maxBHSize = r.readLong()
-            val keyDeposit = r.readLong()
-            val poolDeposit = r.readLong()
-            val eMax = r.readLong()
-            val nOpt = r.readLong()
-
-            // a0 = NonNegativeInterval = Tagged(30, [num, denom])
-            val a0Tag = r.read[Dom.Element]()
-            val (a0Num, a0Denom) = parseTaggedRational(a0Tag)
-
-            // rho = UnitInterval = Tagged(30, [num, denom])
-            val rhoTag = r.read[Dom.Element]()
-            val (rhoNum, rhoDenom) = parseTaggedRational(rhoTag)
-
-            // tau = UnitInterval = Tagged(30, [num, denom])
-            val tauTag = r.read[Dom.Element]()
-            val (tauNum, tauDenom) = parseTaggedRational(tauTag)
-
-            // protocolVersion = [major, minor]
-            r.readArrayHeader(2)
-            val pvMajor = r.readLong()
-            val pvMinor = r.readLong()
-
-            val minPoolCost = r.readLong()
-            val coinsPerUTxOByte = r.readLong()
-
-            // costModels - keep as DOM element
-            val costModels = r.read[Dom.Element]()
-
-            // prices = [memPrice, stepPrice] where each is Tagged(30, [num, denom])
-            r.readArrayHeader(2)
-            val memPriceTag = r.read[Dom.Element]()
-            val (memPriceNum, memPriceDenom) = parseTaggedRational(memPriceTag)
-            val stepPriceTag = r.read[Dom.Element]()
-            val (stepPriceNum, stepPriceDenom) = parseTaggedRational(stepPriceTag)
-
-            // maxTxExUnits = [mem, steps]
-            r.readArrayHeader(2)
-            val maxTxExMem = r.readLong()
-            val maxTxExSteps = r.readLong()
-
-            // maxBlockExUnits = [mem, steps]
-            r.readArrayHeader(2)
-            val maxBlockExMem = r.readLong()
-            val maxBlockExSteps = r.readLong()
-
-            val maxValSize = r.readLong()
-            val collateralPercentage = r.readLong()
-            val maxCollateralInputs = r.readLong()
-
-            // poolVotingThresholds - keep as DOM
-            val poolVotingThresholds = r.read[Dom.Element]()
-
-            // dRepVotingThresholds - keep as DOM
-            val dRepVotingThresholds = r.read[Dom.Element]()
-
-            val committeeMinSize = r.readLong()
-            val committeeMaxTermLength = r.readLong()
-            val govActionLifetime = r.readLong()
-            val govActionDeposit = r.readLong()
-            val dRepDeposit = r.readLong()
-            val dRepActivity = r.readLong()
-
-            // minFeeRefScriptCostPerByte (if present)
-            val (refScriptNum, refScriptDenom) =
-                if size > 30 then
-                    val tag = r.read[Dom.Element]()
-                    parseTaggedRational(tag)
-                else (0L, 1L)
-
-            ConwayProtocolParams(
-              minFeeA = minFeeA,
-              minFeeB = minFeeB,
-              maxBBSize = maxBBSize,
-              maxTxSize = maxTxSize,
-              maxBHSize = maxBHSize,
-              keyDeposit = keyDeposit,
-              poolDeposit = poolDeposit,
-              eMax = eMax,
-              nOpt = nOpt,
-              a0Numerator = a0Num,
-              a0Denominator = a0Denom,
-              rhoNumerator = rhoNum,
-              rhoDenominator = rhoDenom,
-              tauNumerator = tauNum,
-              tauDenominator = tauDenom,
-              protocolVersionMajor = pvMajor,
-              protocolVersionMinor = pvMinor,
-              minPoolCost = minPoolCost,
-              coinsPerUTxOByte = coinsPerUTxOByte,
-              costModelsRaw = costModels,
-              pricesMemNumerator = memPriceNum,
-              pricesMemDenominator = memPriceDenom,
-              pricesStepNumerator = stepPriceNum,
-              pricesStepDenominator = stepPriceDenom,
-              maxTxExMem = maxTxExMem,
-              maxTxExSteps = maxTxExSteps,
-              maxBlockExMem = maxBlockExMem,
-              maxBlockExSteps = maxBlockExSteps,
-              maxValSize = maxValSize,
-              collateralPercentage = collateralPercentage,
-              maxCollateralInputs = maxCollateralInputs,
-              poolVotingThresholdsRaw = poolVotingThresholds,
-              dRepVotingThresholdsRaw = dRepVotingThresholds,
-              committeeMinSize = committeeMinSize,
-              committeeMaxTermLength = committeeMaxTermLength,
-              govActionLifetime = govActionLifetime,
-              govActionDeposit = govActionDeposit,
-              dRepDeposit = dRepDeposit,
-              dRepActivity = dRepActivity,
-              minFeeRefScriptCostPerByteNum = refScriptNum,
-              minFeeRefScriptCostPerByteDen = refScriptDenom
-            )
-
-    private def parseTaggedRational(elem: Dom.Element): (Long, Long) =
-        elem match
-            case tagged: Dom.TaggedElem if tagged.tag.code == 30 =>
-                tagged.value match
-                    case arr: Dom.ArrayElem if arr.elems.size == 2 =>
-                        val num = extractLong(arr.elems(0))
-                        val denom = extractLong(arr.elems(1))
-                        (num, denom)
-                    case other =>
-                        throw new RuntimeException(
-                          s"Expected array of 2 elements in Tagged(30), got $other"
-                        )
-            case other =>
-                throw new RuntimeException(s"Expected Tagged(30, [num, denom]), got $other")
-
-    private def extractLong(elem: Dom.Element): Long =
-        elem match
-            case Dom.IntElem(v)  => v.toLong
-            case Dom.LongElem(v) => v
-            case other => throw new RuntimeException(s"Expected int in rational, got $other")


### PR DESCRIPTION
## Summary

Lifts `ConwayProtocolParams` (case class + CBOR `Decoder` + `fromCbor` + `toProtocolParams`) out of `scalus.testing.conformance.LedgerState` (test source set) into a new `scalus.cardano.ledger.ConwayProtocolParams` in `main`.

## Why

The Conway PParams CBOR shape — what `cardano-ledger`'s \`EncCBOR (PParams Conway)\` produces and the on-disk \`pparams-by-hash\` files contain — was only reachable from test code. Production consumers couldn't decode it.

The motivating consumer: a `LocalStateQuery` driver in scalus-node (M12 work) needs `Decoder[ConwayProtocolParams]` + `.toProtocolParams` to back `BackupSource.LocalNode.fetchLatestParams` against the result of the `GetCurrentPParams` LSQ query.

## What's NOT moved

The fixture helpers `loadFromHash` / `extractPparamsHash` (which index the conformance test vectors' on-disk `pparams-by-hash` directory) stay in test code under a new `ConwayProtocolParamsFixtures` object. They're fixture-loading utilities, not protocol code. The two existing callers (`CardanoLedgerVectors`, `ScriptContextComparisonTest`) have been updated.

## Verification

- `sbt scalusCardanoLedgerJVM/compile` — clean
- `sbt scalusCardanoLedgerJVM/Test/compile` — clean
- `sbt scalusCardanoLedgerIt/Test/compile` — clean
- `sbt scalusCardanoLedgerJVM/testQuick` — 763/763 pass

No behavioural change.

## Test plan

- [x] Main code compiles
- [x] Test code compiles, all `scalusCardanoLedgerJVM` tests pass
- [x] Integration test module (`scalusCardanoLedgerIt`) compiles
- [ ] CI green