### PR TITLE
fix(bls12_381): override hashCode on G1Element/G2Element/MLResult

### DIFF
--- a/scalus-core/js/src/main/scala/scalus/uplc/builtin/bls12_381/BLS.scala
+++ b/scalus-core/js/src/main/scala/scalus/uplc/builtin/bls12_381/BLS.scala
@@ -90,6 +90,7 @@ private[bls12_381] object BLS:
     object GT:
         def isEquals(lhs: GT, rhs: GT): Boolean = bls12_381.fields.gtModule.isEquals(lhs, rhs)
         def multiply(lhs: GT, rhs: GT): GT = bls12_381.fields.gtModule.multiply(lhs, rhs)
+        def toBytes(value: GT): Uint8Array = bls12_381.fields.gtModule.toBytes(value)
 
     @js.native
     trait Fields extends js.Object:
@@ -102,4 +103,5 @@ private[bls12_381] object BLS:
         def isEquals(lhs: GT, rhs: GT): Boolean = js.native
         @JSName("mul")
         def multiply(lhs: GT, rhs: GT): GT = js.native
+        def toBytes(value: GT): Uint8Array = js.native
 end BLS

--- a/scalus-core/js/src/main/scala/scalus/uplc/builtin/bls12_381/MLResult.scala
+++ b/scalus-core/js/src/main/scala/scalus/uplc/builtin/bls12_381/MLResult.scala
@@ -1,5 +1,7 @@
 package scalus.uplc.builtin.bls12_381
 
+import scalus.uplc.builtin.NodeJsPlatformSpecific.toByteString
+
 import scala.compiletime.asMatchable
 import scala.annotation.targetName
 
@@ -11,6 +13,8 @@ class MLResult(private val gt: BLS.GT):
     override def equals(that: Any): Boolean = that.asMatchable match
         case that: MLResult => BLS.GT.isEquals(gt, that.gt)
         case _              => false
+
+    override def hashCode: Int = BLS.GT.toBytes(gt).toByteString.hashCode
 
 object MLResult:
     def apply(elemG1: G1Element, elemG2: G2Element): MLResult =

--- a/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/G1Element.scala
+++ b/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/G1Element.scala
@@ -13,6 +13,8 @@ class G1Element(private[builtin] val value: P1):
         case that: G1Element => value.is_equal(that.value)
         case _               => false
 
+    override def hashCode(): Int = java.util.Arrays.hashCode(value.compress())
+
     // TODO: check if this is correct
     override def toString: String = s"0x${Hex.bytesToHex(value.compress())}"
 

--- a/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/G2Element.scala
+++ b/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/G2Element.scala
@@ -13,6 +13,8 @@ class G2Element(private[builtin] val value: P2):
         case that: G2Element => value.is_equal(that.value)
         case _               => false
 
+    override def hashCode(): Int = java.util.Arrays.hashCode(value.compress())
+
     override def toString: String = s"0x${Hex.bytesToHex(value.compress())}"
 
 object G2Element extends G2ElementOffchainApi:

--- a/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/MLResult.scala
+++ b/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/bls12_381/MLResult.scala
@@ -9,5 +9,7 @@ class MLResult(private[builtin] val value: PT):
         case that: MLResult => value.is_equal(that.value)
         case _              => false
 
+    override def hashCode(): Int = java.util.Arrays.hashCode(value.to_bendian())
+
 object MLResult:
     def apply(value: PT): MLResult = new MLResult(value)

--- a/scalus-core/jvm/src/test/scala/scalus/uplc/builtin/BLS12_381BuiltinsTest.scala
+++ b/scalus-core/jvm/src/test/scala/scalus/uplc/builtin/BLS12_381BuiltinsTest.scala
@@ -129,4 +129,30 @@ class BLS12_381BuiltinsTest extends AnyFunSuite {
             g2"deadbeef" // only 4 bytes, not 96
         }
     }
+
+    test("G1Element equals/hashCode are consistent for equal points") {
+        val a = bls12_381_G1_uncompress(bls12_381_G1_compressed_generator)
+        val b = bls12_381_G1_uncompress(bls12_381_G1_compressed_generator)
+        assert(a == b)
+        assert(a.hashCode == b.hashCode)
+        assert(Set(a).contains(b))
+    }
+
+    test("G2Element equals/hashCode are consistent for equal points") {
+        val a = bls12_381_G2_uncompress(bls12_381_G2_compressed_generator)
+        val b = bls12_381_G2_uncompress(bls12_381_G2_compressed_generator)
+        assert(a == b)
+        assert(a.hashCode == b.hashCode)
+        assert(Set(a).contains(b))
+    }
+
+    test("MLResult equals/hashCode are consistent for equal points") {
+        val g1Elem = bls12_381_G1_uncompress(bls12_381_G1_compressed_generator)
+        val g2Elem = bls12_381_G2_uncompress(bls12_381_G2_compressed_generator)
+        val a = bls12_381_millerLoop(g1Elem, g2Elem)
+        val b = bls12_381_millerLoop(g1Elem, g2Elem)
+        assert(a == b)
+        assert(a.hashCode == b.hashCode)
+        assert(Set(a).contains(b))
+    }
 }


### PR DESCRIPTION
## Summary

- The BLS12-381 wrapper classes (`G1Element`, `G2Element`, `MLResult`) override `equals` to delegate to the native curve library's `is_equal` / `BLS.GT.eql`, but inherited identity-based `hashCode` from `Object`. Two instances representing the same curve point compared equal but had different hash codes, so `HashMap` / `HashSet` / `.distinct` / memoization on these values could silently misbehave in pairing and aggregate-signature flows.
- Hash the canonical compressed serialization: `value.compress()` for JVM G1/G2, `value.to_bendian()` for JVM `MLResult`, `BLS.GT.toBytes(gt)` for JS `MLResult` (binding extended in `BLS.scala`). JVM Native `G1Element` and JS `G1Element`/`G2Element` already had correct overrides; no changes needed there.
- Added three regression tests in `BLS12_381BuiltinsTest` exercising the contract: `a == b ⇒ a.hashCode == b.hashCode`, plus `Set(a).contains(b)` to cover the actual HashMap-misbehavior failure mode.

Fixes #273.

## Test plan

- [x] `scalusJVM/testOnly scalus.cardano.onchain.plutus.prelude.bls12_381.*` — 29 tests passing
- [x] `scalusJVM/testOnly scalus.uplc.builtin.BLS12_381BuiltinsTest` — 18 tests passing (incl. 3 new)
- [x] `scalusJS/Test/compile` clean
- [x] `scalafmtAll`