### PR TITLE
fix(ledger): align NonNegativeInterval hashCode with reduce-based equals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,6 +317,38 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       },
       // scalacOptions += "-Yretain-trees",
       mimaPreviousArtifacts := Set(organization.value %%% name.value % scalusCompatibleVersion),
+      // NonNegativeInterval: converted from case class to regular class so a custom
+      // hashCode matching the reduce-based equals could be supplied without the
+      // case-class machinery falling out of step (issue #272).
+      mimaBinaryIssueFilters ++= Seq(
+        ProblemFilters.exclude[MissingTypesProblem]("scalus.cardano.ledger.NonNegativeInterval"),
+        ProblemFilters.exclude[MissingTypesProblem]("scalus.cardano.ledger.NonNegativeInterval$"),
+        ProblemFilters
+            .exclude[DirectMissingMethodProblem]("scalus.cardano.ledger.NonNegativeInterval._1"),
+        ProblemFilters
+            .exclude[DirectMissingMethodProblem]("scalus.cardano.ledger.NonNegativeInterval._2"),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.canEqual"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.productArity"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.productPrefix"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.productElement"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.productElementName"
+        ),
+        ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.fromProduct"
+        ),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "scalus.cardano.ledger.NonNegativeInterval.unapply"
+        ),
+      ),
 
       // enable when debug compilation of tests
       Test / scalacOptions += "-color:never",

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,7 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       // hashCode matching the reduce-based equals could be supplied without the
       // case-class machinery falling out of step (issue #272).
       mimaBinaryIssueFilters ++= Seq(
+        ProblemFilters.exclude[FinalClassProblem]("scalus.cardano.ledger.NonNegativeInterval"),
         ProblemFilters.exclude[MissingTypesProblem]("scalus.cardano.ledger.NonNegativeInterval"),
         ProblemFilters.exclude[MissingTypesProblem]("scalus.cardano.ledger.NonNegativeInterval$"),
         ProblemFilters

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/NonNegativeInterval.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/NonNegativeInterval.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
   * @param denominator
   *   The denominator of the fraction (positive)
   */
-class NonNegativeInterval(val numerator: Long, val denominator: Long) {
+final class NonNegativeInterval(val numerator: Long, val denominator: Long) {
     // Validate constraints
     require(numerator >= 0, "Numerator must be non-negative")
     require(denominator > 0, "Denominator must be positive")
@@ -210,8 +210,9 @@ object NonNegativeInterval {
     def apply(numerator: Long, denominator: Long): NonNegativeInterval =
         new NonNegativeInterval(numerator, denominator)
 
-    def unapply(x: NonNegativeInterval): Some[(Long, Long)] =
-        Some((x.numerator, x.denominator))
+    def unapply(x: NonNegativeInterval): Option[(Long, Long)] =
+        if x eq null then None
+        else Some((x.numerator, x.denominator))
 
     val zero: NonNegativeInterval = NonNegativeInterval(0, 1)
 

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/NonNegativeInterval.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/NonNegativeInterval.scala
@@ -17,7 +17,7 @@ import scala.annotation.tailrec
   * @param denominator
   *   The denominator of the fraction (positive)
   */
-case class NonNegativeInterval(numerator: Long, denominator: Long) {
+class NonNegativeInterval(val numerator: Long, val denominator: Long) {
     // Validate constraints
     require(numerator >= 0, "Numerator must be non-negative")
     require(denominator > 0, "Denominator must be positive")
@@ -31,6 +31,19 @@ case class NonNegativeInterval(numerator: Long, denominator: Long) {
             case _ => false
         }
     }
+
+    override def hashCode(): Int = {
+        val r = this.reduce
+        (r.numerator, r.denominator).hashCode()
+    }
+
+    override def toString: String = s"NonNegativeInterval($numerator,$denominator)"
+
+    def copy(
+        numerator: Long = this.numerator,
+        denominator: Long = this.denominator
+    ): NonNegativeInterval =
+        new NonNegativeInterval(numerator, denominator)
 
     /** Multiplication operation with Int.
       *
@@ -194,6 +207,12 @@ case class NonNegativeInterval(numerator: Long, denominator: Long) {
 }
 
 object NonNegativeInterval {
+    def apply(numerator: Long, denominator: Long): NonNegativeInterval =
+        new NonNegativeInterval(numerator, denominator)
+
+    def unapply(x: NonNegativeInterval): Some[(Long, Long)] =
+        Some((x.numerator, x.denominator))
+
     val zero: NonNegativeInterval = NonNegativeInterval(0, 1)
 
     def reduce(numerator: Long, denominator: Long): NonNegativeInterval = {

--- a/scalus-core/shared/src/test/scala/scalus/cardano/ledger/NonNegativeIntervalTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/cardano/ledger/NonNegativeIntervalTest.scala
@@ -144,8 +144,14 @@ class NonNegativeIntervalTest extends AnyFunSuite with ScalaCheckPropertyChecks:
         }
 
     test("unapply destructures into raw numerator/denominator"):
-        val NonNegativeInterval(n, d) = NonNegativeInterval(2, 4)
-        assert(n == 2L && d == 4L)
+        NonNegativeInterval(2, 4) match
+            case NonNegativeInterval(n, d) =>
+                assert(n == 2L && d == 4L)
+            case _ => fail("unapply returned None")
+
+    test("unapply on null returns None"):
+        val nullInterval: NonNegativeInterval = null
+        assert(NonNegativeInterval.unapply(nullInterval).isEmpty)
 
     test("copy preserves raw numerator/denominator"):
         val original = NonNegativeInterval(2, 4)

--- a/scalus-core/shared/src/test/scala/scalus/cardano/ledger/NonNegativeIntervalTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/cardano/ledger/NonNegativeIntervalTest.scala
@@ -1,5 +1,6 @@
 package scalus.cardano.ledger
 
+import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
@@ -122,3 +123,33 @@ class NonNegativeIntervalTest extends AnyFunSuite with ScalaCheckPropertyChecks:
         // Large GCD
         val large = NonNegativeInterval.reduce(1000000000, 1000000000)
         assert(large == NonNegativeInterval(1, 1))
+
+    test("equals and hashCode agree on equivalent fractions"):
+        val a = NonNegativeInterval(2, 4)
+        val b = NonNegativeInterval(1, 2)
+        assert(a == b)
+        assert(a.hashCode == b.hashCode)
+        assert(Set(a).contains(b))
+        assert(Map(a -> "half").get(b).contains("half"))
+
+    test("equals and hashCode work across many fraction reductions"):
+        val numerator = Gen.chooseNum(0L, 1_000_000_000L)
+        val denominator = Gen.chooseNum(1L, 1_000_000_000L)
+        val factor = Gen.chooseNum(1L, 1_000_000L)
+        forAll(numerator, denominator, factor) { (n, d, k) =>
+            val a = NonNegativeInterval(n, d)
+            val b = NonNegativeInterval(n * k, d * k)
+            assert(a == b)
+            assert(a.hashCode == b.hashCode)
+        }
+
+    test("unapply destructures into raw numerator/denominator"):
+        val NonNegativeInterval(n, d) = NonNegativeInterval(2, 4)
+        assert(n == 2L && d == 4L)
+
+    test("copy preserves raw numerator/denominator"):
+        val original = NonNegativeInterval(2, 4)
+        val copied = original.copy()
+        assert(copied.numerator == 2L && copied.denominator == 4L)
+        val newDenom = original.copy(denominator = 8)
+        assert(newDenom.numerator == 2L && newDenom.denominator == 8L)


### PR DESCRIPTION
## Summary

- `NonNegativeInterval` was a case class with `equals` overridden to compare reduced fractions, but `hashCode` was left as the case-class default deriving from the raw `(numerator, denominator)`. `NonNegativeInterval(2, 4) == NonNegativeInterval(1, 2)` was `true`, yet their hashes differed, so `HashMap` / `HashSet` / `.distinct` silently missed equivalent fractions.
- Converted to a regular class with hand-written `apply`/`unapply`/`copy` in the companion. `hashCode` now hashes the reduced form, matching the existing `equals`. The class-shape change mirrors the project's stance against mixing custom `equals` with case-class machinery (see prior `SIRType.TypeVar` conversion).
- No call sites use `.copy` or pattern match on `(numerator, denominator)`, so the change is invisible at the source level. The case-class-to-class transition does affect bytecode (loss of `Product`, `Mirror$Product`, synthetic `_1`/`_2`/`productArity`/`fromProduct`, plus a `unapply` return-type change); MIMA filters for the eleven affected entries are added in `build.sbt`.

Fixes #272.

## Test plan

- [x] `scalusJVM/testOnly scalus.cardano.ledger.NonNegativeIntervalTest` — 10 tests passing, including 4 new (equals/hashCode/Set/Map consistency, a ScalaCheck property over reduced fractions, `unapply` destructuring, `copy` preserves raw fields)
- [x] `scalafmtAll` + `scalafmtSbt`
- [x] MIMA breaks for `NonNegativeInterval` are all filtered explicitly; pre-existing unrelated MIMA failures against `0.15.0` are untouched