### PR TITLE
refactor(lowering): extract buildProdUplcConstrRepr helper

### DIFF
--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProdUplcConstrOps.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProdUplcConstrOps.scala
@@ -106,6 +106,28 @@ object ProdUplcConstrOps {
         loweredValue
     }
 
+    /** Builds the `ProdUplcConstr` repr for product type `tp` by mapping each constructor parameter
+      * to its field-level repr. When `honorFieldAnnotations` is true (Data-compatible emitter),
+      * field-level `@UplcRepr` annotations override the parameter type's natural repr; otherwise
+      * (non-Data emitter) the natural repr is used unconditionally.
+      */
+    def buildProdUplcConstrRepr(
+        tp: SIRType,
+        honorFieldAnnotations: Boolean
+    )(using lctx: LoweringContext): ProdUplcConstr = {
+        val constrIndex = ProductCaseEmitter.retrieveConstrIndex(tp, SIRPosition.empty)
+        val constrDecl = ProductCaseEmitter.retrieveConstrDecl(tp, SIRPosition.empty)
+        val fieldReprs = constrDecl.params.map { param =>
+            val paramType = lctx.resolveTypeVarIfNeeded(param.tp)
+            if honorFieldAnnotations then
+                SirTypeUplcGenerator
+                    .resolveFieldRepr(param, paramType)
+                    .getOrElse(SirTypeUplcGenerator.defaultRepresentation(paramType))
+            else SirTypeUplcGenerator.defaultRepresentation(paramType)
+        }
+        ProdUplcConstr(constrIndex, fieldReprs)
+    }
+
     /** Returns true if `tp` (or any unwrapped form) carries a class-level `@UplcRepr` annotation in
       * its constrDecl. Used by `genConstr` to decide whether the field's static type pins a
       * specific repr that arg.repr must conform to.

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrEmitter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrEmitter.scala
@@ -14,20 +14,8 @@ object ProductCaseUplcConstrEmitter extends SirTypeUplcGenerator {
 
     override def defaultRepresentation(tp: SIRType)(using
         lctx: LoweringContext
-    ): LoweredValueRepresentation = {
-        val constrIndex = ProductCaseEmitter.retrieveConstrIndex(tp, SIRPosition.empty)
-        val constrDecl = ProductCaseEmitter.retrieveConstrDecl(tp, SIRPosition.empty)
-        val fieldReprs = constrDecl.params.map { param =>
-            val paramType = lctx.resolveTypeVarIfNeeded(param.tp)
-            // Check for field-level @UplcRepr annotation override
-            SirTypeUplcGenerator
-                .resolveFieldRepr(param, paramType)
-                .getOrElse(
-                  SirTypeUplcGenerator.defaultRepresentation(paramType)
-                )
-        }
-        ProductCaseClassRepresentation.ProdUplcConstr(constrIndex, fieldReprs)
-    }
+    ): LoweredValueRepresentation =
+        ProdUplcConstrOps.buildProdUplcConstrRepr(tp, honorFieldAnnotations = true)
 
     override def defaultDataRepresentation(
         tp: SIRType

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrOnlyEmitter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrOnlyEmitter.scala
@@ -10,15 +10,8 @@ object ProductCaseUplcConstrOnlyEmitter extends SirTypeUplcGenerator {
 
     override def defaultRepresentation(tp: SIRType)(using
         lctx: LoweringContext
-    ): LoweredValueRepresentation = {
-        val constrIndex = ProductCaseEmitter.retrieveConstrIndex(tp, SIRPosition.empty)
-        val constrDecl = ProductCaseEmitter.retrieveConstrDecl(tp, SIRPosition.empty)
-        val fieldReprs = constrDecl.params.map { param =>
-            val paramType = lctx.resolveTypeVarIfNeeded(param.tp)
-            SirTypeUplcGenerator.defaultRepresentation(paramType)
-        }
-        ProductCaseClassRepresentation.ProdUplcConstr(constrIndex, fieldReprs)
-    }
+    ): LoweredValueRepresentation =
+        ProdUplcConstrOps.buildProdUplcConstrRepr(tp, honorFieldAnnotations = false)
 
     override def defaultDataRepresentation(
         tp: SIRType


### PR DESCRIPTION
Replace the duplicated field-repr-building loop in ProductCaseUplcConstrEmitter and ProductCaseUplcConstrOnlyEmitter with a shared ProdUplcConstrOps.buildProdUplcConstrRepr helper. The honorFieldAnnotations toggle preserves the asymmetry: the Data-compatible emitter still consults field-level @UplcRepr overrides, while the non-Data emitter uses the parameter type's natural repr unconditionally.