### PR TITLE
Update cardano-client-backend-blockfrost, cardano-client-lib to 0.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val scalusStableVersion = "0.17.0"
 val scalusCompatibleVersion = scalusStableVersion
 
 // Bloxbean Cardano Client Library versions
-val cardanoClientLibVersion = "0.7.1"
+val cardanoClientLibVersion = "0.7.2"
 val yaciVersion = "0.4.4"
 val yaciCardanoTestVersion = "0.1.0"
 val nobleCurvesVersion = "1.9.7"


### PR DESCRIPTION
Bumps `com.bloxbean.cardano` cardano-client-lib / cardano-client-backend-blockfrost from 0.7.1 to 0.7.2.

Supersedes scala-steward PR #287, which had a trivial adjacent-line merge conflict (master bumped `yaciVersion` to 0.4.4 on the line directly below) and could not be updated on the fork. This branch applies the same bump on top of current master.