### PR TITLE
fix: stable, self-describing evaluator dumps + report config (#93)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ node_modules
 .cursor/
 **/todo/
 *.log
+log.uplc.*
 test-logs-archive/
 /scalus-cardano-ledger/js/src/main/npm/scalus.js.map
 scalus-examples/jvm/src/test/resources/scalus/examples/AikenMpfData/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `EvaluatorReportConfig` — typed configuration for `PlutusScriptEvaluator` diagnostic output
+  (output directory, artifact selection, profile level), overridable via the `SCALUS_DUMP`,
+  `SCALUS_DUMP_DIR`, and `SCALUS_PROFILE*` environment variables; new `PlutusScriptEvaluator.apply`
+  overload accepting it. The legacy `debugDumpFilesForTesting: Boolean` constructors are retained
+  and map onto it
+- `platform.createDirectories` for cross-platform directory creation
+
+### Changed
+
+- Evaluator debug dumps now use stable, overwriting filenames
+  (`<scriptHash>-<language>-<tag>-<index>.flat`) instead of the volatile `script-<txid>-…` names,
+  so fee-balancing re-evaluations overwrite rather than accumulate duplicate files; the per-builtin
+  budget log is truncated once per evaluation (previously appended without bound) and renamed to
+  `budget.log`; a `manifest.json` describing every dumped script is written alongside (#93)
+
 ## 0.17.0 (2026-05-05)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 ### Added
 
 - `EvaluatorReportConfig` — typed configuration for `PlutusScriptEvaluator` diagnostic output
-  (output directory, artifact selection, profile level), overridable via the `SCALUS_DUMP`,
+  (output directory, artifact selection, profile level/outputs), overridable via the `SCALUS_DUMP`,
   `SCALUS_DUMP_DIR`, and `SCALUS_PROFILE*` environment variables; new `PlutusScriptEvaluator.apply`
   overload accepting it. The legacy `debugDumpFilesForTesting: Boolean` constructors are retained
   and map onto it
-- `platform.createDirectories` for cross-platform directory creation
+- profiling integrated into `PlutusScriptEvaluator`: when enabled (`SCALUS_PROFILE=summary|full`,
+  `SCALUS_PROFILE_OUT=…`, or `EvaluatorReportConfig.profile`), each script's profile is rendered to
+  the console or to per-script files. Output formats: a compact text summary, CSV, JSON, and a
+  **self-contained interactive HTML report** — sortable/filterable tables with %-of-CPU bars, a
+  per-line cost-annotated source view, and a transition-matrix heatmap with a hot-edges table
+- `ProfileFormatter.toCsv` / `toJson` / `summary`, and `toHtml(data, sources)` with source
+  annotation; `platform.createDirectories` and `platform.fileExists` for cross-platform file I/O
 
 ### Changed
 

--- a/scalus-cardano-ledger-it/src/test/scala/scalus/testing/conformance/ScriptContextComparisonTest.scala
+++ b/scalus-cardano-ledger-it/src/test/scala/scalus/testing/conformance/ScriptContextComparisonTest.scala
@@ -21,9 +21,16 @@ import scalus.utils.Hex
 class ScriptContextComparisonTest extends AnyFunSuite with BeforeAndAfterEach {
 
     override def afterEach(): Unit = {
-        // Clean up script-*.flat files created by debugDumpFilesForTesting
+        // Clean up dump artifacts created by debugDumpFilesForTesting:
+        // <scriptHash>-<language>-<tag>-<index>.flat plus the manifest / budget log.
         val currentDir = new File(".")
-        currentDir.listFiles().filter(_.getName.matches("script-.*\\.flat")).foreach(_.delete())
+        currentDir
+            .listFiles()
+            .filter { f =>
+                val n = f.getName
+                n.matches(".*-PlutusV\\d-.*\\.flat") || n == "manifest.json" || n == "budget.log"
+            }
+            .foreach(_.delete())
         super.afterEach()
     }
 

--- a/scalus-cardano-ledger/jvm/src/test/scala/eval/EvalPlutusScriptsTest.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/eval/EvalPlutusScriptsTest.scala
@@ -5,6 +5,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import scalus.uplc.builtin.platform
 import scalus.cardano.ledger.*
 
+import java.nio.file.Files
+
 class EvalPlutusScriptsTest extends AnyFunSuite {
 
     test("evalPlutusScripts with CBOR files") {
@@ -27,10 +29,56 @@ class EvalPlutusScriptsTest extends AnyFunSuite {
         assert(redeemers.length == 2, "Should have 2 redeemers evaluated")
     }
 
+    test("report dumps use stable names + manifest and overwrite on re-evaluation") {
+        val dir = Files.createTempDirectory("scalus-dump-test")
+        try {
+            val report = EvaluatorReportConfig(
+              enabled = true,
+              outputDir = dir.toString,
+              artifacts = Set(DumpArtifact.Flat)
+            )
+
+            // Two evaluations of the same tx must not accumulate duplicate files.
+            evalPlutusScripts(tx7430, utxo7430, SlotConfig.mainnet, report)
+            evalPlutusScripts(tx7430, utxo7430, SlotConfig.mainnet, report)
+
+            val flats = Option(dir.toFile.listFiles())
+                .getOrElse(Array.empty[java.io.File])
+                .map(_.getName)
+                .filter(_.endsWith(".flat"))
+                .sorted
+
+            assert(flats.length == 2, s"expected 2 stable .flat files, got ${flats.mkString(", ")}")
+            assert(
+              flats.forall(_.matches(".*-PlutusV\\d-.*\\.flat")),
+              s"flat names should encode scriptHash/language/tag/index, got ${flats.mkString(", ")}"
+            )
+
+            val manifest = new String(
+              Files.readAllBytes(dir.resolve("manifest.json")),
+              "UTF-8"
+            )
+            assert(manifest.contains("\"txId\""))
+            assert(manifest.contains("\"scripts\""))
+            assert(manifest.contains("\"spentBudget\""))
+        } finally
+            // Best-effort cleanup of the temp dir
+            Option(dir.toFile.listFiles()).getOrElse(Array.empty[java.io.File]).foreach(_.delete())
+            Files.deleteIfExists(dir)
+    }
+
+    private lazy val tx7430: Array[Byte] = platform.readFile(
+      "scalus-examples/js/src/main/ts/tx-743042177a25ed7675d6258211df87cd7dcc208d2fa82cb32ac3c77221bd87c3.cbor"
+    )
+    private lazy val utxo7430: Array[Byte] = platform.readFile(
+      "scalus-examples/js/src/main/ts/utxo-743042177a25ed7675d6258211df87cd7dcc208d2fa82cb32ac3c77221bd87c3.cbor"
+    )
+
     def evalPlutusScripts(
         txCborBytes: Array[Byte],
         utxoCborBytes: Array[Byte],
-        slotConfig: SlotConfig
+        slotConfig: SlotConfig,
+        report: EvaluatorReportConfig = EvaluatorReportConfig.disabled
     ): Seq[Redeemer] = {
         val tx = Transaction.fromCbor(txCborBytes)
         val utxo =
@@ -43,7 +91,8 @@ class EvalPlutusScriptsTest extends AnyFunSuite {
           protocolMajorVersion = CardanoInfo.mainnet.majorProtocolVersion,
           costModels = costModels,
           mode = EvaluatorMode.EvaluateAndComputeCost,
-          debugDumpFilesForTesting = false
+          report = report,
+          logBudgetDifferences = false
         )
         evaluator.evalPlutusScripts(tx, utxo)
     }

--- a/scalus-cardano-ledger/jvm/src/test/scala/eval/EvalPlutusScriptsTest.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/eval/EvalPlutusScriptsTest.scala
@@ -67,6 +67,39 @@ class EvalPlutusScriptsTest extends AnyFunSuite {
             Files.deleteIfExists(dir)
     }
 
+    test("profile = Full writes per-script HTML + CSV reports") {
+        val dir = Files.createTempDirectory("scalus-profile-test")
+        try {
+            val report = EvaluatorReportConfig(
+              enabled = true,
+              outputDir = dir.toString,
+              artifacts = Set.empty, // profile only, no .flat dump
+              profile = ProfileLevel.Full
+            )
+            evalPlutusScripts(tx7430, utxo7430, SlotConfig.mainnet, report)
+
+            val files = Option(dir.toFile.listFiles())
+                .getOrElse(Array.empty[java.io.File])
+                .map(_.getName)
+            assert(
+              files.exists(_.endsWith(".profile.html")),
+              s"expected a profile.html, got ${files.mkString(", ")}"
+            )
+            assert(
+              files.exists(_.endsWith(".profile.csv")),
+              s"expected a profile.csv, got ${files.mkString(", ")}"
+            )
+            val htmlName = files.find(_.endsWith(".profile.html")).get
+            val html = new String(Files.readAllBytes(dir.resolve(htmlName)), "UTF-8")
+            assert(html.contains("Scalus CEK Machine Profile"))
+            assert(html.contains("By Source Location"))
+        } finally
+            Option(dir.toFile.listFiles())
+                .getOrElse(Array.empty[java.io.File])
+                .foreach(_.delete())
+            Files.deleteIfExists(dir)
+    }
+
     private lazy val tx7430: Array[Byte] = platform.readFile(
       "scalus-examples/js/src/main/ts/tx-743042177a25ed7675d6258211df87cd7dcc208d2fa82cb32ac3c77221bd87c3.cbor"
     )

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -355,6 +355,47 @@ object PlutusScriptEvaluator {
 
         private def budgetLogPath: String = reportPath("budget.log")
 
+        /** Render a script's profile to each configured [[ProfileOutput]] (console / files). File
+          * destinations are prefixed with the script key so per-redeemer profiles don't collide.
+          * HTML output annotates source lines when the source file is readable from the CWD.
+          */
+        private def renderProfile(
+            result: Result,
+            scriptHash: ScriptHash,
+            redeemer: Redeemer
+        ): Unit = result.profile.foreach { data =>
+            val outs = report.effectiveProfileOutputs
+            val sources: Map[String, IndexedSeq[String]] =
+                if outs.exists(_.format == ProfileFormat.Html) then
+                    data.bySourceLocation
+                        .map(_.file)
+                        .distinct
+                        .filter(platform.fileExists)
+                        .map(f =>
+                            f -> new String(platform.readFile(f), "UTF-8").split('\n').toIndexedSeq
+                        )
+                        .toMap
+                else Map.empty
+            val key = s"${scriptHash.toHex}-${redeemer.tag}-${redeemer.index}"
+            outs.foreach { out =>
+                val content = out.format match
+                    case ProfileFormat.Text =>
+                        if report.profile == ProfileLevel.Full then
+                            ProfileFormatter.toText(data, report.maxRows)
+                        else ProfileFormatter.summary(data)
+                    case ProfileFormat.Csv  => ProfileFormatter.toCsv(data)
+                    case ProfileFormat.Html => ProfileFormatter.toHtml(data, sources)
+                    case ProfileFormat.Json => ProfileFormatter.toJson(data)
+                out.destination match
+                    case ProfileDestination.Console =>
+                        log.info(s"Profile $key:\n$content")
+                    case ProfileDestination.File(name) =>
+                        platform.writeFile(reportPath(s"$key.$name"), content.getBytes("UTF-8"))
+                    case ProfileDestination.AbsoluteFile(path) =>
+                        platform.writeFile(path, content.getBytes("UTF-8"))
+            }
+        }
+
         private val log = Logger()
         //        .withHandler(minimumLevel = Some(Level.Debug))
 
@@ -676,6 +717,12 @@ object PlutusScriptEvaluator {
             // Execute the script
             try
                 val resultTerm = vm.evaluateScript(applied, spender, logger)
+                if report.enabled && report.profile != ProfileLevel.Off then
+                    renderProfile(
+                      vm.evaluateScriptProfile(applied),
+                      plutusScript.scriptHash,
+                      redeemer
+                    )
                 Result.Success(resultTerm, spender.getSpentBudget, Map.empty, logger.getLogs.toSeq)
             catch
                 case e: StackTraceMachineError =>

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -358,6 +358,12 @@ object PlutusScriptEvaluator {
         /** Render a script's profile to each configured [[ProfileOutput]] (console / files). File
           * destinations are prefixed with the script key so per-redeemer profiles don't collide.
           * HTML output annotates source lines when the source file is readable from the CWD.
+          *
+          * @note
+          *   This is fed by a *separate* profiling evaluation of the script (see the call site), so
+          *   enabling profiling roughly doubles evaluation cost. That profiling pass counts budget
+          *   but does not enforce the redeemer's execution-unit limit, so it is only run after the
+          *   real (budget-enforcing) evaluation has already succeeded.
           */
         private def renderProfile(
             result: Result,
@@ -385,6 +391,8 @@ object PlutusScriptEvaluator {
                     case ProfileDestination.File(name) =>
                         platform.writeFile(reportPath(s"$key.$name"), content.getBytes("UTF-8"))
                     case ProfileDestination.AbsoluteFile(path) =>
+                        val sep = math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+                        if sep > 0 then platform.createDirectories(path.substring(0, sep))
                         platform.writeFile(path, content.getBytes("UTF-8"))
             }
         }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -367,14 +367,7 @@ object PlutusScriptEvaluator {
             val outs = report.effectiveProfileOutputs
             val sources: Map[String, IndexedSeq[String]] =
                 if outs.exists(_.format == ProfileFormat.Html) then
-                    data.bySourceLocation
-                        .map(_.file)
-                        .distinct
-                        .filter(platform.fileExists)
-                        .map(f =>
-                            f -> new String(platform.readFile(f), "UTF-8").split('\n').toIndexedSeq
-                        )
-                        .toMap
+                    ProfileFormatter.loadSources(data)
                 else Map.empty
             val key = s"${scriptHash.toHex}-${redeemer.tag}-${redeemer.index}"
             outs.foreach { out =>

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/ledger/PlutusScriptEvaluator.scala
@@ -224,7 +224,7 @@ object PlutusScriptEvaluator {
       CardanoInfo.mainnet.majorProtocolVersion,
       CardanoInfo.mainnet.protocolParams.costModels,
       EvaluatorMode.EvaluateAndComputeCost,
-      debugDumpFilesForTesting = false
+      report = EvaluatorReportConfig.disabled
     ) {
         override protected def evalScript(
             redeemer: Redeemer,
@@ -276,7 +276,33 @@ object PlutusScriptEvaluator {
           protocolMajorVersion,
           costModels,
           mode,
-          debugDumpFilesForTesting,
+          EvaluatorReportConfig.fromEnv(
+            EvaluatorReportConfig.fromLegacyBoolean(debugDumpFilesForTesting)
+          ),
+          logBudgetDifferences
+        )
+
+    /** Factory method taking a typed [[EvaluatorReportConfig]] instead of the legacy boolean.
+      *
+      * Environment overrides (`SCALUS_DUMP*` / `SCALUS_PROFILE*`) are layered on top of `report`
+      * field-by-field; see [[EvaluatorReportConfig.fromEnv]].
+      */
+    def apply(
+        slotConfig: SlotConfig,
+        initialBudget: ExUnits,
+        protocolMajorVersion: MajorProtocolVersion,
+        costModels: CostModels,
+        mode: EvaluatorMode,
+        report: EvaluatorReportConfig,
+        logBudgetDifferences: Boolean
+    ): PlutusScriptEvaluator =
+        new DefaultImpl(
+          slotConfig,
+          initialBudget,
+          protocolMajorVersion,
+          costModels,
+          mode,
+          EvaluatorReportConfig.fromEnv(report),
           logBudgetDifferences
         )
 
@@ -307,9 +333,27 @@ object PlutusScriptEvaluator {
         val protocolMajorVersion: MajorProtocolVersion,
         val costModels: CostModels,
         val mode: EvaluatorMode,
-        val debugDumpFilesForTesting: Boolean,
+        val report: EvaluatorReportConfig,
         val logBudgetDifferences: Boolean = false
     ) extends PlutusScriptEvaluator {
+
+        /** Path under [[report]]'s output directory, or the bare name when the dir is the CWD. */
+        private def reportPath(name: String): String =
+            if report.outputDir.isEmpty || report.outputDir == "." then name
+            else s"${report.outputDir}/$name"
+
+        /** Stable, overwriting dump file name for a script's fully-applied program. Keyed on the
+          * script hash (not the volatile txid), so re-evaluations during fee balancing overwrite
+          * rather than accumulate.
+          */
+        private def flatFileName(
+            scriptHash: ScriptHash,
+            language: Language,
+            redeemer: Redeemer
+        ): String =
+            s"${scriptHash.toHex}-$language-${redeemer.tag}-${redeemer.index}.flat"
+
+        private def budgetLogPath: String = reportPath("budget.log")
 
         private val log = Logger()
         //        .withHandler(minimumLevel = Some(Level.Debug))
@@ -350,6 +394,8 @@ object PlutusScriptEvaluator {
             debugScripts: Map[ScriptHash, DebugScript] = Map.empty
         ): Seq[(Redeemer, ScriptContext, ScriptHash)] = {
             log.debug(s"Starting Phase 2 evaluation for transaction: ${tx.id}")
+
+            if report.enabled then prepareReportDir()
 
             val redeemers = tx.witnessSet.redeemers.map(_.value.toMap).getOrElse(Map.empty)
 
@@ -452,7 +498,10 @@ object PlutusScriptEvaluator {
                 }
 
             log.debug(s"Phase 2 evaluation completed. Remaining budget: $remainingBudget")
-            evaluatedRedeemers.toSeq
+            val result = evaluatedRedeemers.toSeq
+            if report.enabled && report.dumps(DumpArtifact.Flat) then
+                writeManifest(tx, result, scriptsMap)
+            result
         }
 
         /** Evaluate a Plutus V1 script with the V1 script context.
@@ -609,8 +658,8 @@ object PlutusScriptEvaluator {
                 acc $ arg
 
             // Optional debug dumping
-            if debugDumpFilesForTesting then
-                dumpScriptForDebugging(applied, redeemer, txhash, vm.language)
+            if report.dumps(DumpArtifact.Flat) then
+                dumpScriptForDebugging(applied, plutusScript.scriptHash, redeemer, vm.language)
 
             // Create budget spender based on evaluation mode
             val spender = mode match
@@ -618,7 +667,8 @@ object PlutusScriptEvaluator {
                 case EvaluatorMode.Validate =>
                     RestrictingBudgetSpenderWithScriptDump(
                       redeemer.exUnits,
-                      debugDumpFilesForTesting
+                      report.dumps(DumpArtifact.BudgetLog),
+                      budgetLogPath
                     )
 
             val logger = Log()
@@ -701,17 +751,61 @@ object PlutusScriptEvaluator {
                             )
         }
 
-        /** Dump script information for debugging purposes.
-          */
+        /** Dump a script's fully-applied program to a stable, overwriting `.flat` file. */
         private def dumpScriptForDebugging(
             program: DeBruijnedProgram,
+            scriptHash: ScriptHash,
             redeemer: Redeemer,
-            txhash: String,
             language: Language
         ): Unit = {
-            val filename = s"script-$txhash-$language-${redeemer.tag}-${redeemer.index}.flat"
-            platform.writeFile(filename, program.flatEncoded)
+            val filename = flatFileName(scriptHash, language, redeemer)
+            platform.writeFile(reportPath(filename), program.flatEncoded)
         }
+
+        /** Prepare the report output directory before an evaluation: create the directory and
+          * truncate `budget.log` so it reflects a single evaluation rather than accumulating across
+          * runs (the root cause of the inflated counts in #93).
+          */
+        private def prepareReportDir(): Unit = {
+            platform.createDirectories(report.outputDir)
+            if report.dumps(DumpArtifact.BudgetLog) && mode == EvaluatorMode.Validate then
+                platform.writeFile(budgetLogPath, Array.emptyByteArray)
+        }
+
+        /** Write `manifest.json` describing every dumped script for the (latest) evaluation. */
+        private def writeManifest(
+            tx: Transaction,
+            evaluated: Seq[(Redeemer, ?, ScriptHash)],
+            scripts: Map[ScriptHash, Script]
+        ): Unit = {
+            val entries = evaluated
+                .distinctBy { case (r, _, h) => (h, r.tag, r.index) }
+                .flatMap { case (r, _, h) =>
+                    scripts.get(h).collect { case ps: PlutusScript =>
+                        manifestEntryJson(flatFileName(h, ps.language, r), h, ps.language, r)
+                    }
+                }
+            val json =
+                s"""{
+                   |  "txId": "${tx.id.toHex}",
+                   |  "protocolVersion": ${protocolMajorVersion.version},
+                   |  "scripts": [
+                   |${entries.mkString(",\n")}
+                   |  ]
+                   |}
+                   |""".stripMargin
+            platform.writeFile(reportPath("manifest.json"), json.getBytes("UTF-8"))
+        }
+
+        private def manifestEntryJson(
+            file: String,
+            scriptHash: ScriptHash,
+            language: Language,
+            redeemer: Redeemer
+        ): String =
+            s"""    { "file": "$file", "scriptHash": "${scriptHash.toHex}", """ +
+                s""""language": "$language", "tag": "${redeemer.tag}", "index": ${redeemer.index}, """ +
+                s""""spentBudget": { "mem": ${redeemer.exUnits.memory}, "cpu": ${redeemer.exUnits.steps} } }"""
 
         /** Extract all scripts from transaction and UTxOs.
           */

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/ledger/EvaluatorReportConfigTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/ledger/EvaluatorReportConfigTest.scala
@@ -1,0 +1,70 @@
+package scalus.cardano.ledger
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class EvaluatorReportConfigTest extends AnyFunSuite {
+
+    test("disabled is the default and dumps nothing") {
+        val cfg = EvaluatorReportConfig.disabled
+        assert(!cfg.enabled)
+        DumpArtifact.values.foreach(a => assert(!cfg.dumps(a)))
+    }
+
+    test("fromLegacyBoolean reproduces the historical artifact set") {
+        val on = EvaluatorReportConfig.fromLegacyBoolean(true)
+        assert(on.enabled)
+        assert(on.artifacts == Set(DumpArtifact.Flat, DumpArtifact.BudgetLog))
+        assert(on.profile == ProfileLevel.Off)
+
+        assert(EvaluatorReportConfig.fromLegacyBoolean(false) == EvaluatorReportConfig.disabled)
+    }
+
+    test("fromEnv leaves base untouched when no relevant vars are present") {
+        val base = EvaluatorReportConfig.fromLegacyBoolean(true)
+        assert(EvaluatorReportConfig.fromEnv(base, Map.empty) == base)
+        assert(EvaluatorReportConfig.fromEnv(base, Map("UNRELATED" -> "x")) == base)
+    }
+
+    test("SCALUS_DUMP enables and selects artifacts") {
+        val cfg = EvaluatorReportConfig.fromEnv(
+          EvaluatorReportConfig.disabled,
+          Map("SCALUS_DUMP" -> "flat,budget")
+        )
+        assert(cfg.enabled)
+        assert(cfg.artifacts == Set(DumpArtifact.Flat, DumpArtifact.BudgetLog))
+    }
+
+    test("SCALUS_DUMP=off is a kill-switch over an enabled base") {
+        val cfg = EvaluatorReportConfig.fromEnv(
+          EvaluatorReportConfig.fromLegacyBoolean(true),
+          Map("SCALUS_DUMP" -> "off")
+        )
+        assert(!cfg.enabled)
+    }
+
+    test("SCALUS_DUMP_DIR overrides only the output directory") {
+        val base = EvaluatorReportConfig.fromLegacyBoolean(true)
+        val cfg = EvaluatorReportConfig.fromEnv(base, Map("SCALUS_DUMP_DIR" -> "target/dump"))
+        assert(cfg.outputDir == "target/dump")
+        assert(cfg.artifacts == base.artifacts)
+        assert(cfg.enabled == base.enabled)
+    }
+
+    test("SCALUS_PROFILE sets level and enables") {
+        val cfg = EvaluatorReportConfig.fromEnv(
+          EvaluatorReportConfig.disabled,
+          Map("SCALUS_PROFILE" -> "full")
+        )
+        assert(cfg.enabled)
+        assert(cfg.profile == ProfileLevel.Full)
+    }
+
+    test("numeric overrides parse, bad values are ignored") {
+        val cfg = EvaluatorReportConfig.fromEnv(
+          EvaluatorReportConfig.disabled,
+          Map("SCALUS_PROFILE_THRESHOLD" -> "0.25", "SCALUS_PROFILE_MAX_ROWS" -> "nan")
+        )
+        assert(cfg.profileThreshold == 0.25)
+        assert(cfg.maxRows == EvaluatorReportConfig.disabled.maxRows)
+    }
+}

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/ledger/EvaluatorReportConfigTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/ledger/EvaluatorReportConfigTest.scala
@@ -59,6 +59,18 @@ class EvaluatorReportConfigTest extends AnyFunSuite {
         assert(cfg.profile == ProfileLevel.Full)
     }
 
+    test("SCALUS_PROFILE=off clears level and derived outputs") {
+        val base = EvaluatorReportConfig(
+          enabled = true,
+          profile = ProfileLevel.Full,
+          profileOutputs = Seq(ProfileOutput(ProfileFormat.Html, ProfileDestination.File("p.html")))
+        )
+        val cfg = EvaluatorReportConfig.fromEnv(base, Map("SCALUS_PROFILE" -> "off"))
+        assert(cfg.profile == ProfileLevel.Off)
+        assert(cfg.profileOutputs.isEmpty)
+        assert(cfg.effectiveProfileOutputs.isEmpty)
+    }
+
     test("numeric overrides parse, bad values are ignored") {
         val cfg = EvaluatorReportConfig.fromEnv(
           EvaluatorReportConfig.disabled,

--- a/scalus-core/js/src/main/scala/scalus/uplc/builtin/JSPlatformSpecific.scala
+++ b/scalus-core/js/src/main/scala/scalus/uplc/builtin/JSPlatformSpecific.scala
@@ -314,6 +314,11 @@ trait NodeJsPlatformSpecific extends PlatformSpecific {
         fs.mkdirSync(path, js.Dynamic.literal(recursive = true))
         ()
     }
+
+    override def fileExists(path: String): Boolean = {
+        val fs = js.Dynamic.global.require("fs")
+        fs.existsSync(path).asInstanceOf[Boolean]
+    }
 }
 
 object NodeJsPlatformSpecific extends NodeJsPlatformSpecific

--- a/scalus-core/js/src/main/scala/scalus/uplc/builtin/JSPlatformSpecific.scala
+++ b/scalus-core/js/src/main/scala/scalus/uplc/builtin/JSPlatformSpecific.scala
@@ -308,6 +308,12 @@ trait NodeJsPlatformSpecific extends PlatformSpecific {
         val uint8Array = new Uint8Array(int8Array.buffer, int8Array.byteOffset, int8Array.length)
         fs.appendFileSync(path, uint8Array)
     }
+
+    override def createDirectories(path: String): Unit = {
+        val fs = js.Dynamic.global.require("fs")
+        fs.mkdirSync(path, js.Dynamic.literal(recursive = true))
+        ()
+    }
 }
 
 object NodeJsPlatformSpecific extends NodeJsPlatformSpecific

--- a/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/JVMPlatformSpecific.scala
+++ b/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/JVMPlatformSpecific.scala
@@ -295,6 +295,11 @@ trait JVMPlatformSpecific extends PlatformSpecific {
         )
         ()
     }
+
+    override def createDirectories(path: String): Unit = {
+        Files.createDirectories(Paths.get(path))
+        ()
+    }
 }
 
 given PlatformSpecific = JVMPlatformSpecific

--- a/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/JVMPlatformSpecific.scala
+++ b/scalus-core/jvm/src/main/scala/scalus/uplc/builtin/JVMPlatformSpecific.scala
@@ -300,6 +300,8 @@ trait JVMPlatformSpecific extends PlatformSpecific {
         Files.createDirectories(Paths.get(path))
         ()
     }
+
+    override def fileExists(path: String): Boolean = Files.isRegularFile(Paths.get(path))
 }
 
 given PlatformSpecific = JVMPlatformSpecific

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
@@ -152,7 +152,7 @@ object EvaluatorReportConfig {
         }
 
         env.get("SCALUS_PROFILE").map(_.trim.toLowerCase).foreach {
-            case "off"     => cfg = cfg.copy(profile = ProfileLevel.Off)
+            case "off"     => cfg = cfg.copy(profile = ProfileLevel.Off, profileOutputs = Nil)
             case "summary" => cfg = cfg.copy(enabled = true, profile = ProfileLevel.Summary)
             case "full"    => cfg = cfg.copy(enabled = true, profile = ProfileLevel.Full)
             case _         => // ignore unrecognised value

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
@@ -75,6 +75,22 @@ final case class EvaluatorReportConfig(
 
     /** True when reporting is enabled and the given artifact is requested. */
     def dumps(artifact: DumpArtifact): Boolean = enabled && artifacts.contains(artifact)
+
+    /** The profile renderings to produce: explicit [[profileOutputs]] when set, otherwise derived
+      * from the [[profile]] level (Summary ⇒ compact text to the console; Full ⇒ HTML + CSV files).
+      */
+    def effectiveProfileOutputs: Seq[ProfileOutput] =
+        if profileOutputs.nonEmpty then profileOutputs
+        else
+            profile match
+                case ProfileLevel.Off => Nil
+                case ProfileLevel.Summary =>
+                    Seq(ProfileOutput(ProfileFormat.Text, ProfileDestination.Console))
+                case ProfileLevel.Full =>
+                    Seq(
+                      ProfileOutput(ProfileFormat.Html, ProfileDestination.File("profile.html")),
+                      ProfileOutput(ProfileFormat.Csv, ProfileDestination.File("profile.csv"))
+                    )
 }
 
 object EvaluatorReportConfig {
@@ -106,6 +122,8 @@ object EvaluatorReportConfig {
       *   - `SCALUS_DUMP` — comma list of `flat`,`cbor`,`budget`,`profile` (or `off`)
       *   - `SCALUS_DUMP_DIR` — output directory
       *   - `SCALUS_PROFILE` — `off` | `summary` | `full`
+      *   - `SCALUS_PROFILE_OUT` — comma list of destinations: `-`/`console` to display, or a file
+      *     name (format inferred from `.html`/`.csv`/`.json`/`.txt`); enables profiling
       *   - `SCALUS_PROFILE_THRESHOLD` — budget fraction (Double)
       *   - `SCALUS_PROFILE_MAX_ROWS` — Int
       *
@@ -140,6 +158,28 @@ object EvaluatorReportConfig {
             case _         => // ignore unrecognised value
         }
 
+        env.get("SCALUS_PROFILE_OUT").map(_.trim).filter(_.nonEmpty).foreach { spec =>
+            val outs = spec
+                .split(",")
+                .iterator
+                .map(_.trim)
+                .filter(_.nonEmpty)
+                .map {
+                    case "-" | "console" | "stdout" =>
+                        ProfileOutput(ProfileFormat.Text, ProfileDestination.Console)
+                    case path if path.startsWith("/") =>
+                        ProfileOutput(formatFromName(path), ProfileDestination.AbsoluteFile(path))
+                    case name =>
+                        ProfileOutput(formatFromName(name), ProfileDestination.File(name))
+                }
+                .toSeq
+            cfg = cfg.copy(
+              enabled = true,
+              profileOutputs = outs,
+              profile = if cfg.profile == ProfileLevel.Off then ProfileLevel.Full else cfg.profile
+            )
+        }
+
         env.get("SCALUS_PROFILE_THRESHOLD").flatMap(_.trim.toDoubleOption).foreach { t =>
             cfg = cfg.copy(profileThreshold = t)
         }
@@ -157,4 +197,12 @@ object EvaluatorReportConfig {
         case "budget" | "budgetlog" => Some(DumpArtifact.BudgetLog)
         case "profile"              => Some(DumpArtifact.Profile)
         case _                      => None
+
+    /** Infer a [[ProfileFormat]] from a destination file extension, defaulting to `Text`. */
+    private def formatFromName(name: String): ProfileFormat =
+        val lower = name.toLowerCase
+        if lower.endsWith(".html") || lower.endsWith(".htm") then ProfileFormat.Html
+        else if lower.endsWith(".csv") then ProfileFormat.Csv
+        else if lower.endsWith(".json") then ProfileFormat.Json
+        else ProfileFormat.Text
 }

--- a/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
+++ b/scalus-core/shared/src/main/scala/scalus/cardano/ledger/EvaluatorReportConfig.scala
@@ -1,0 +1,160 @@
+package scalus.cardano.ledger
+
+/** Which diagnostic artifacts the evaluator writes when reporting is enabled.
+  *
+  * @see
+  *   [[EvaluatorReportConfig]]
+  */
+enum DumpArtifact:
+    /** Fully-applied `.flat` program, one file per script. */
+    case Flat
+
+    /** Transaction + inputs + outputs CBOR (for `aiken tx simulate`). Wired in a later step. */
+    case TxCbor
+
+    /** Per-builtin cost log (`VALIDATE` mode only). */
+    case BudgetLog
+
+    /** Rendered [[scalus.uplc.eval.ProfilingData]] report. Wired in a later step. */
+    case Profile
+
+/** How verbose a rendered profile is. */
+enum ProfileLevel:
+    case Off, Summary, Full
+
+/** Output format for a rendered profile. */
+enum ProfileFormat:
+    case Text, Csv, Html, Json
+
+/** Where a single rendered profile is written. */
+enum ProfileDestination:
+    /** Standard out / log — "display". */
+    case Console
+
+    /** A file name resolved under [[EvaluatorReportConfig.outputDir]] if relative. */
+    case File(name: String)
+
+    /** An exact path, ignoring [[EvaluatorReportConfig.outputDir]]. */
+    case AbsoluteFile(path: String)
+
+/** One profile rendering: a format plus where it lands. */
+final case class ProfileOutput(format: ProfileFormat, destination: ProfileDestination)
+
+/** Controls all diagnostic output of [[PlutusScriptEvaluator]].
+  *
+  * Replaces the former lone `debugDumpFilesForTesting: Boolean`. Construct one directly, derive one
+  * from the legacy boolean with [[EvaluatorReportConfig.fromLegacyBoolean]], or layer environment
+  * overrides on top with [[EvaluatorReportConfig.fromEnv]].
+  *
+  * @param enabled
+  *   master switch; when `false` the evaluator writes nothing
+  * @param outputDir
+  *   directory artifacts are written to (plain string so the type stays cross-platform; created via
+  *   `platform.createDirectories`). Default `"."` is the current working directory, matching the
+  *   historical dump location.
+  * @param artifacts
+  *   which [[DumpArtifact]]s to write
+  * @param profile
+  *   profile verbosity (rendering is wired in a later step)
+  * @param profileOutputs
+  *   explicit profile renderings; empty ⇒ derived from `profile`
+  * @param profileThreshold
+  *   rows below this fraction of total budget collapse into "... and N more"
+  * @param maxRows
+  *   row cap per profile section
+  */
+final case class EvaluatorReportConfig(
+    enabled: Boolean = false,
+    outputDir: String = ".",
+    artifacts: Set[DumpArtifact] = Set(DumpArtifact.Flat),
+    profile: ProfileLevel = ProfileLevel.Off,
+    profileOutputs: Seq[ProfileOutput] = Nil,
+    profileThreshold: Double = 0.01,
+    maxRows: Int = 50
+) {
+
+    /** True when reporting is enabled and the given artifact is requested. */
+    def dumps(artifact: DumpArtifact): Boolean = enabled && artifacts.contains(artifact)
+}
+
+object EvaluatorReportConfig {
+
+    /** Reporting fully off — the default. */
+    val disabled: EvaluatorReportConfig = EvaluatorReportConfig()
+
+    /** Map the legacy `debugDumpFilesForTesting` boolean onto a config.
+      *
+      * `true` reproduces the historical artifact set: the fully-applied `.flat` files plus the
+      * per-builtin budget log (the latter only takes effect in `VALIDATE` mode). The on-disk layout
+      * changes — stable, overwriting filenames plus a `manifest.json` — but the set of artifacts is
+      * unchanged.
+      */
+    def fromLegacyBoolean(debugDumpFilesForTesting: Boolean): EvaluatorReportConfig =
+        if debugDumpFilesForTesting then
+            EvaluatorReportConfig(
+              enabled = true,
+              artifacts = Set(DumpArtifact.Flat, DumpArtifact.BudgetLog)
+            )
+        else disabled
+
+    /** Layer environment overrides on top of `base`, field by field.
+      *
+      * Only variables that are present change anything; absent variables leave `base` untouched.
+      * Presence of `SCALUS_DUMP` / `SCALUS_PROFILE` flips `enabled = true`; `SCALUS_DUMP=off` (also
+      * `false`/`none`) is an explicit kill-switch that forces `enabled = false`.
+      *
+      *   - `SCALUS_DUMP` — comma list of `flat`,`cbor`,`budget`,`profile` (or `off`)
+      *   - `SCALUS_DUMP_DIR` — output directory
+      *   - `SCALUS_PROFILE` — `off` | `summary` | `full`
+      *   - `SCALUS_PROFILE_THRESHOLD` — budget fraction (Double)
+      *   - `SCALUS_PROFILE_MAX_ROWS` — Int
+      *
+      * `env` is injectable so the precedence rules can be unit-tested without touching the process
+      * environment.
+      */
+    def fromEnv(
+        base: EvaluatorReportConfig = disabled,
+        env: Map[String, String] = sys.env
+    ): EvaluatorReportConfig = {
+        var cfg = base
+
+        env.get("SCALUS_DUMP").map(_.trim.toLowerCase).foreach {
+            case "off" | "false" | "none" | "" =>
+                cfg = cfg.copy(enabled = false)
+            case value =>
+                val parsed = value.split(",").iterator.map(_.trim).flatMap(parseArtifact).toSet
+                cfg = cfg.copy(
+                  enabled = true,
+                  artifacts = if parsed.nonEmpty then parsed else cfg.artifacts
+                )
+        }
+
+        env.get("SCALUS_DUMP_DIR").map(_.trim).filter(_.nonEmpty).foreach { dir =>
+            cfg = cfg.copy(outputDir = dir)
+        }
+
+        env.get("SCALUS_PROFILE").map(_.trim.toLowerCase).foreach {
+            case "off"     => cfg = cfg.copy(profile = ProfileLevel.Off)
+            case "summary" => cfg = cfg.copy(enabled = true, profile = ProfileLevel.Summary)
+            case "full"    => cfg = cfg.copy(enabled = true, profile = ProfileLevel.Full)
+            case _         => // ignore unrecognised value
+        }
+
+        env.get("SCALUS_PROFILE_THRESHOLD").flatMap(_.trim.toDoubleOption).foreach { t =>
+            cfg = cfg.copy(profileThreshold = t)
+        }
+
+        env.get("SCALUS_PROFILE_MAX_ROWS").flatMap(_.trim.toIntOption).foreach { n =>
+            cfg = cfg.copy(maxRows = n)
+        }
+
+        cfg
+    }
+
+    private def parseArtifact(name: String): Option[DumpArtifact] = name match
+        case "flat"                 => Some(DumpArtifact.Flat)
+        case "cbor" | "txcbor"      => Some(DumpArtifact.TxCbor)
+        case "budget" | "budgetlog" => Some(DumpArtifact.BudgetLog)
+        case "profile"              => Some(DumpArtifact.Profile)
+        case _                      => None
+}

--- a/scalus-core/shared/src/main/scala/scalus/uplc/builtin/PlatformSpecific.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/builtin/PlatformSpecific.scala
@@ -277,6 +277,14 @@ trait PlatformSpecific:
       */
     def createDirectories(path: String): Unit = ()
 
+    /** Whether a readable file exists at `path`. The default returns `false` for platforms (and
+      * browsers) without filesystem access; overridden on JVM and Node.js.
+      *
+      * @param path
+      *   The file path to test
+      */
+    def fileExists(path: String): Boolean = false
+
 @Compile
 object PlatformSpecific:
     val bls12_381_scalar_period: BigInt =

--- a/scalus-core/shared/src/main/scala/scalus/uplc/builtin/PlatformSpecific.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/builtin/PlatformSpecific.scala
@@ -265,6 +265,18 @@ trait PlatformSpecific:
       */
     def appendFile(path: String, bytes: Array[Byte]): Unit
 
+    /** Create the directory at `path` and any missing parent directories. Idempotent — succeeds if
+      * the directory already exists.
+      *
+      * @note
+      *   This method is only meaningful in Node.js, JVM, and Native environments. The default
+      *   implementation is a no-op for platforms (and browsers) without filesystem access.
+      *
+      * @param path
+      *   The directory path to create
+      */
+    def createDirectories(path: String): Unit = ()
+
 @Compile
 object PlatformSpecific:
     val bls12_381_scalar_period: BigInt =

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/Cek.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/Cek.scala
@@ -952,6 +952,12 @@ class CekMachine(
         private val callEdges = HashMap[(String, Int, String, Int), Long]()
         private var prevFile: String = ""
         private var prevLine: Int = 0
+        // The first distinct located steps in execution order. The hot-path tree roots at the first
+        // of these that belongs to a contract file (the formatter knows which); the literal first
+        // step is often a framework/annotation-fallback location, not the contract's own entry.
+        private val entryTrace = ArrayBuffer[(String, Int)]()
+        private val entrySeen = scala.collection.mutable.HashSet[(String, Int)]()
+        private val entryTraceCap = 64
         // A call has begun; its edge is completed at the first *located* step inside the body (so it
         // survives the empty source positions that optimized UPLC leaves on Apply/LamAbs nodes).
         private var callPending: Boolean = false
@@ -978,6 +984,7 @@ class CekMachine(
                 val file = pos.file
                 val line = pos.startLine + 1
                 val key = (file, line)
+                if entryTrace.size < entryTraceCap && entrySeen.add(key) then entryTrace += key
                 val arr = byLocation.getOrElseUpdate(key, new Array[Long](3))
                 arr(0) += mem
                 arr(1) += steps
@@ -1066,7 +1073,8 @@ class CekMachine(
               functions,
               builtinsByLocation,
               transitionSeq,
-              wrapped.getSpentBudget
+              wrapped.getSpentBudget,
+              entryTrace = entryTrace.toSeq
             )
         }
     }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/Cek.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/Cek.scala
@@ -670,8 +670,10 @@ object Result:
 type ArgStack = Seq[CekValue]
 
 private enum Context {
-    case FrameAwaitArg(f: CekValue, ctx: Context)
-    case FrameAwaitFunTerm(env: CekValEnv, term: Term, ctx: Context)
+    // `callPos` carries the source position of the originating `Apply` so the profiler can record a
+    // call edge (call site → callee body) when the function is finally entered (beta-reduction).
+    case FrameAwaitArg(f: CekValue, ctx: Context, callPos: ScalusSourcePos)
+    case FrameAwaitFunTerm(env: CekValEnv, term: Term, ctx: Context, callPos: ScalusSourcePos)
     case FrameAwaitFunValue(value: CekValue, ctx: Context)
     case FrameForce(ctx: Context)
     case FrameConstr(env: CekValEnv, tag: Word64, rest: Seq[Term], args: ArgStack, ctx: Context)
@@ -945,10 +947,27 @@ class CekMachine(
         private val byFunction = new Array[Array[Long]](DefaultFun.values.length)
         // Per-location per-builtin: (file, line, builtinOrdinal) → [mem, cpu, count]
         private val byLocationFunction = HashMap[(String, Int, Int), Array[Long]]()
-        // Transition counts: (fromFile, fromLine, toFile, toLine) → count
-        private val transitions = HashMap[(String, Int, String, Int), Long]()
+        // Call edges (caller → callee body): (fromFile, fromLine, toFile, toLine) → count. Recorded
+        // only at beta-reduction (onCall), so this is a true call graph — no return back-edges.
+        private val callEdges = HashMap[(String, Int, String, Int), Long]()
         private var prevFile: String = ""
         private var prevLine: Int = 0
+        // A call has begun; its edge is completed at the first *located* step inside the body (so it
+        // survives the empty source positions that optimized UPLC leaves on Apply/LamAbs nodes).
+        private var callPending: Boolean = false
+        private var pendCallerFile: String = ""
+        private var pendCallerLine: Int = 0
+
+        /** Note a beta-reduction. `callPos` is the originating `Apply`'s position when annotated,
+          * else we fall back to the last known location; the callee end is resolved lazily in
+          * `spendBudget` from the body's first located step.
+          */
+        def onCall(callPos: ScalusSourcePos): Unit =
+            callPending = true
+            if !callPos.isEmpty then
+                pendCallerFile = callPos.file; pendCallerLine = callPos.startLine + 1
+            else
+                pendCallerFile = prevFile; pendCallerLine = prevLine
 
         def spendBudget(cat: ExBudgetCategory, budget: ExUnits, env: CekValEnv): Unit = {
             wrapped.spendBudget(cat, budget, env)
@@ -963,13 +982,16 @@ class CekMachine(
                 arr(0) += mem
                 arr(1) += steps
                 arr(2) += 1
-                // Track transitions between source locations
-                if prevFile.nonEmpty && ((file ne prevFile) || line != prevLine) then
-                    val tkey = (prevFile, prevLine, file, line)
-                    transitions.updateWith(tkey) {
-                        case Some(c) => Some(c + 1)
-                        case None    => Some(1)
-                    }
+                // Complete a pending call edge at the first located step of the callee body.
+                if callPending then
+                    callPending = false
+                    if pendCallerFile.nonEmpty && (pendCallerFile != file || pendCallerLine != line)
+                    then
+                        val tkey = (pendCallerFile, pendCallerLine, file, line)
+                        callEdges.updateWith(tkey) {
+                            case Some(c) => Some(c + 1)
+                            case None    => Some(1)
+                        }
                 prevFile = file
                 prevLine = line
             cat match
@@ -1032,7 +1054,7 @@ class CekMachine(
                 .toSeq
                 .sortBy(e => (-e.memory, -e.cpu))
 
-            val transitionSeq = transitions.iterator
+            val transitionSeq = callEdges.iterator
                 .map { case ((fromFile, fromLine, toFile, toLine), count) =>
                     SourceTransition(fromFile, fromLine, toFile, toLine, count)
                 }
@@ -1052,6 +1074,12 @@ class CekMachine(
     private val effectiveSpender: BudgetSpender =
         if profiling then new ProfilingBudgetSpender(budgetSpender)
         else budgetSpender
+
+    // Non-null only when profiling; lets the hot path record call edges with a single null check.
+    private val profilingSpenderOrNull: ProfilingBudgetSpender | Null =
+        effectiveSpender match
+            case p: ProfilingBudgetSpender => p
+            case _                         => null
 
     /** Returns profiling data if profiling was enabled, None otherwise. */
     def getProfile: Option[ProfilingData] = effectiveSpender match
@@ -1108,7 +1136,7 @@ class CekMachine(
                 Return(ctx, env, VLamAbs(name, term, env))
             case Apply(fun, arg, _) =>
                 spendBudget(ExBudgetCategory.Step(StepKind.Apply), costs.applyCost, env)
-                Compute(FrameAwaitFunTerm(env, arg, ctx), env, fun)
+                Compute(FrameAwaitFunTerm(env, arg, ctx, term.sourcePos), env, fun)
             case Force(term, _) =>
                 spendBudget(ExBudgetCategory.Step(StepKind.Force), costs.forceCost, env)
                 Compute(FrameForce(ctx), env, term)
@@ -1139,11 +1167,13 @@ class CekMachine(
 
     private def returnCek(ctx: Context, env: CekValEnv, value: CekValue): CekState = {
         ctx match
-            case NoFrame                          => Done(dischargeCekValue(value))
-            case FrameForce(ctx)                  => forceEvaluate(ctx, env, value)
-            case FrameAwaitFunTerm(env, arg, ctx) => Compute(FrameAwaitArg(value, ctx), env, arg)
-            case FrameAwaitArg(fun, ctx)          => applyEvaluate(ctx, env, fun, value)
-            case FrameAwaitFunValue(arg, ctx)     => applyEvaluate(ctx, env, value, arg)
+            case NoFrame         => Done(dischargeCekValue(value))
+            case FrameForce(ctx) => forceEvaluate(ctx, env, value)
+            case FrameAwaitFunTerm(env, arg, ctx, callPos) =>
+                Compute(FrameAwaitArg(value, ctx, callPos), env, arg)
+            case FrameAwaitArg(fun, ctx, callPos) => applyEvaluate(ctx, env, fun, value, callPos)
+            case FrameAwaitFunValue(arg, ctx) =>
+                applyEvaluate(ctx, env, value, arg, ScalusSourcePos.empty)
             case FrameConstr(env, tag, todo, evaled, ctx) =>
                 val newEvaled = evaled :+ value
                 todo match
@@ -1425,7 +1455,8 @@ class CekMachine(
         ctx: Context,
         env: CekValEnv,
         fun: CekValue,
-        arg: CekValue
+        arg: CekValue,
+        callPos: ScalusSourcePos
     ): CekState = {
         // Diagnostic (gated by -Dscalus.assert.apply.data.to.uc=1):
         // catches the BIND moment where Data.Constr bytes flow into a slot
@@ -1483,7 +1514,12 @@ class CekMachine(
                         case _ => ()
                 case _ => ()
         fun match
-            case VLamAbs(name, term, env) => Compute(ctx, env :+ (name, arg), term)
+            case VLamAbs(name, term, env) =>
+                // Beta-reduction = entering a function body: record a call edge (call site → body)
+                // for the profiler. Stateless (no runtime stack), so tail calls stay constant-space.
+                val ps = profilingSpenderOrNull
+                if ps != null then ps.onCall(callPos)
+                Compute(ctx, env :+ (name, arg), term)
             case VBuiltin(fun, term, runtime) =>
                 val term1 = () => Apply(term(), dischargeCekValue(arg))
                 runtime.typeScheme match

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -1,5 +1,7 @@
 package scalus.uplc.eval
 
+import scalus.uplc.builtin.platform
+
 object ProfileFormatter {
 
     /** Max rows rendered per HTML table before collapsing into a "… and N more" note. */
@@ -53,8 +55,8 @@ object ProfileFormatter {
                 sb.append(s"  ... and ${data.bySourceLocation.size - effectiveMaxRows} more\n")
 
         sb.append('\n')
-        sb.append("=== Profile by Function ===\n")
-        if data.byFunction.isEmpty then sb.append("  (no functions recorded)\n")
+        sb.append("=== Profile by Builtin ===\n")
+        if data.byFunction.isEmpty then sb.append("  (no builtins recorded)\n")
         else
             val rows = data.byFunction.take(effectiveMaxRows)
             val nameWidth = math.max(8, rows.map(_.name.length).max)
@@ -64,7 +66,7 @@ object ProfileFormatter {
 
             sb.append(
               formatRow(
-                "function",
+                "builtin",
                 "count",
                 "mem",
                 "cpu",
@@ -140,7 +142,7 @@ object ProfileFormatter {
         val sb = new StringBuilder
         sb.append(s"Total: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}\n")
         if data.byFunction.nonEmpty then
-            sb.append(s"Top $n by CPU (function):\n")
+            sb.append(s"Top $n by CPU (builtin):\n")
             data.byFunction.sortBy(e => -e.cpu).take(n).foreach { e =>
                 sb.append(
                   "  " + e.name.padTo(24, ' ') + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}\n"
@@ -165,11 +167,18 @@ object ProfileFormatter {
             sb.append(csvRow("location", s"${e.file}:${e.line}", "", e.count, e.memory, e.cpu))
         )
         data.byFunction.foreach(e =>
-            sb.append(csvRow("function", e.name, "", e.count, e.memory, e.cpu))
+            sb.append(csvRow("builtin", e.name, "", e.count, e.memory, e.cpu))
         )
         data.byLocationFunction.foreach(e =>
             sb.append(
-              csvRow("builtin", s"${e.file}:${e.line}", e.functionName, e.count, e.memory, e.cpu)
+              csvRow(
+                "loc-builtin",
+                s"${e.file}:${e.line}",
+                e.functionName,
+                e.count,
+                e.memory,
+                e.cpu
+              )
             )
         )
         data.transitions.foreach(t =>
@@ -261,6 +270,61 @@ object ProfileFormatter {
       */
     def toHtml(data: ProfilingData, sources: Map[String, IndexedSeq[String]]): String = {
         val totalCpu = math.max(1L, data.totalBudget.steps)
+
+        // Build each section's inner HTML; only non-empty sections become tabs. Section titles
+        // live on the tab buttons, so the panels themselves carry no <h2>.
+        val sections = scala.collection.mutable.ArrayBuffer[(String, String, String)]()
+        def section(id: String, title: String)(render: StringBuilder => Unit): Unit = {
+            val b = new StringBuilder
+            render(b)
+            sections += ((id, title, b.toString))
+        }
+
+        section("src", "By Source Location")(
+          appendCostTable(
+            _,
+            Seq("Location"),
+            data.bySourceLocation.map(e =>
+                (Seq(s"${shortFile(e.file)}:${e.line}"), e.count, e.memory, e.cpu)
+            ),
+            totalCpu
+          )
+        )
+
+        renderAnnotatedSource(data, sources).foreach(html =>
+            sections += (("annotated", "Annotated Source", html))
+        )
+
+        section("fun", "By Builtin")(
+          appendCostTable(
+            _,
+            Seq("Builtin"),
+            data.byFunction.map(e => (Seq(e.name), e.count, e.memory, e.cpu)),
+            totalCpu
+          )
+        )
+
+        if data.byLocationFunction.nonEmpty then
+            section("lf", "Builtins by Source Location")(
+              appendCostTable(
+                _,
+                Seq("Location", "Function"),
+                data.byLocationFunction.map(e =>
+                    (
+                      Seq(s"${shortFile(e.file)}:${e.line}", e.functionName),
+                      e.count,
+                      e.memory,
+                      e.cpu
+                    )
+                ),
+                totalCpu
+              )
+            )
+
+        if data.transitions.nonEmpty then
+            section("matrix", "Transition Matrix")(appendTransitionMatrix(_, data))
+            section("edges", "Hot Edges")(appendHotEdges(_, data))
+
         val sb = new StringBuilder
         sb.append(
           "<!DOCTYPE html>\n<html><head><meta charset=\"utf-8\"><title>Scalus Profile</title>\n<style>\n"
@@ -274,45 +338,71 @@ object ProfileFormatter {
           "<input id=\"filter\" class=\"filter\" placeholder=\"filter rows by text…\" oninput=\"scalusFilter(this.value)\">\n"
         )
 
-        sb.append("<h2>By Source Location</h2>\n")
-        appendCostTable(
-          sb,
-          Seq("Location"),
-          data.bySourceLocation.map(e =>
-              (Seq(s"${shortFile(e.file)}:${e.line}"), e.count, e.memory, e.cpu)
-          ),
-          totalCpu
-        )
-
-        appendAnnotatedSource(sb, data, sources)
-
-        sb.append("<h2>By Function</h2>\n")
-        appendCostTable(
-          sb,
-          Seq("Function"),
-          data.byFunction.map(e => (Seq(e.name), e.count, e.memory, e.cpu)),
-          totalCpu
-        )
-
-        if data.byLocationFunction.nonEmpty then
-            sb.append("<h2>Builtins by Source Location</h2>\n")
-            appendCostTable(
-              sb,
-              Seq("Location", "Function"),
-              data.byLocationFunction.map(e =>
-                  (Seq(s"${shortFile(e.file)}:${e.line}", e.functionName), e.count, e.memory, e.cpu)
-              ),
-              totalCpu
+        sb.append("<nav class=\"tabs\">\n")
+        sections.zipWithIndex.foreach { case ((id, title, _), i) =>
+            val active = if i == 0 then " active" else ""
+            sb.append(
+              s"""<button class="tab-btn$active" data-tab="$id">${escapeHtml(title)}</button>\n"""
             )
+        }
+        sb.append("</nav>\n")
 
-        if data.transitions.nonEmpty then
-            appendTransitionMatrix(sb, data)
-            appendHotEdges(sb, data)
+        sections.zipWithIndex.foreach { case ((id, _, content), i) =>
+            val hidden = if i == 0 then "" else " hidden"
+            sb.append(s"""<section class="tab-panel" id="$id"$hidden>\n""")
+            sb.append(content)
+            sb.append("</section>\n")
+        }
 
         sb.append("<script>\n")
         sb.append(htmlScript)
         sb.append("\n</script>\n</body></html>")
         sb.toString
+    }
+
+    /** Source files referenced by `data`, loaded best-effort (only files readable from the current
+      * working directory) so the HTML report can annotate them with per-line cost.
+      *
+      * @param include
+      *   keep only files whose path satisfies this predicate. Use it to skip framework/library
+      *   sources and annotate only your own contract — e.g. `!_.contains("/scalus-core/")`. For
+      *   projects that depend on Scalus as a published artifact, library sources live in jars and
+      *   are already excluded (they are not readable files).
+      */
+    def loadSources(
+        data: ProfilingData,
+        include: String => Boolean = _ => true
+    ): Map[String, IndexedSeq[String]] =
+        data.bySourceLocation
+            .map(_.file)
+            .distinct
+            .filter(include)
+            .filter(platform.fileExists)
+            .map(f => f -> new String(platform.readFile(f), "UTF-8").split('\n').toIndexedSeq)
+            .toMap
+
+    /** Write a self-contained, source-annotated HTML report to `path` (creating parent dirs).
+      *
+      * @param include
+      *   source-file filter for the annotated-source view (see [[loadSources]])
+      */
+    def writeHtml(
+        data: ProfilingData,
+        path: String,
+        include: String => Boolean = _ => true
+    ): Unit =
+        writeTo(path, toHtml(data, loadSources(data, include)))
+
+    /** Write the CSV rendering to `path` (creating parent dirs). */
+    def writeCsv(data: ProfilingData, path: String): Unit = writeTo(path, toCsv(data))
+
+    /** Write the JSON rendering to `path` (creating parent dirs). */
+    def writeJson(data: ProfilingData, path: String): Unit = writeTo(path, toJson(data))
+
+    private def writeTo(path: String, content: String): Unit = {
+        val sep = math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+        if sep > 0 then platform.createDirectories(path.substring(0, sep))
+        platform.writeFile(path, content.getBytes("UTF-8"))
     }
 
     /** A sortable/filterable cost table: label column(s) + count, mem, cpu and a %-of-CPU bar. */
@@ -347,17 +437,15 @@ object ProfileFormatter {
     /** Per-line cost-annotated source: each line shown with its cpu/mem/count and a heat background
       * proportional to its share of the file's CPU. Only files present in `sources` are rendered.
       */
-    private def appendAnnotatedSource(
-        sb: StringBuilder,
+    private def renderAnnotatedSource(
         data: ProfilingData,
         sources: Map[String, IndexedSeq[String]]
-    ): Unit = {
-        if sources.isEmpty then return
+    ): Option[String] = {
         val byFile = data.bySourceLocation.groupBy(_.file)
         val files =
             sources.keys.filter(byFile.contains).toSeq.sortBy(f => -byFile(f).map(_.cpu).sum)
-        if files.isEmpty then return
-        sb.append("<h2>Annotated Source</h2>\n")
+        if files.isEmpty then return None
+        val sb = new StringBuilder
         files.foreach { file =>
             val lines = sources(file)
             val perLine = byFile(file).map(e => e.line -> e).toMap
@@ -380,6 +468,7 @@ object ProfileFormatter {
             }
             sb.append("</table>\n")
         }
+        Some(sb.toString)
     }
 
     /** Transition matrix heatmap: top-N locations by CPU on each axis; cell = transition count. */
@@ -400,7 +489,6 @@ object ProfileFormatter {
                 cells((fi, ti)) = v
                 if v > maxCount then maxCount = v
         }
-        sb.append("<h2>Transition Matrix</h2>\n")
         sb.append(
           s"<p>Top ${nodes.size} locations by CPU; cell = transition count (row = from, column = to).</p>\n"
         )
@@ -428,7 +516,6 @@ object ProfileFormatter {
 
     /** Sortable hot-edges table (from → to, count), the full edge list behind the matrix. */
     private def appendHotEdges(sb: StringBuilder, data: ProfilingData): Unit = {
-        sb.append("<h2>Hot Edges</h2>\n")
         sb.append(
           "<table class='sortable'><thead><tr><th>From</th><th>To</th><th>Count</th></tr></thead><tbody>\n"
         )
@@ -511,10 +598,20 @@ table.src { border: none; width: 100%; }
 table.src td { border: none; padding: 0 8px; }
 table.src td.ln { color: #999; text-align: right; user-select: none; }
 table.src td.cost { color: #b00; text-align: right; white-space: nowrap; }
-table.src td.code { text-align: left; white-space: pre; }"""
+table.src td.code { text-align: left; white-space: pre; }
+nav.tabs { position: sticky; top: 0; background: #fafafa; padding: 8px 0; margin-bottom: 12px; border-bottom: 1px solid #ccc; z-index: 10; }
+.tab-btn { font-family: monospace; font-size: 0.95em; padding: 5px 12px; margin: 0 4px 0 0; border: 1px solid #ccc; background: #eee; color: #333; cursor: pointer; border-radius: 4px 4px 0 0; }
+.tab-btn:hover { background: #e0e8f0; }
+.tab-btn.active { background: #4a90d9; border-color: #4a90d9; color: #fff; }
+.tab-panel[hidden] { display: none; }"""
 
     private val htmlScript: String =
         """function scalusFilter(q){q=(q||'').toLowerCase();document.querySelectorAll('table.sortable tbody tr').forEach(function(tr){tr.style.display=tr.textContent.toLowerCase().indexOf(q)>=0?'':'none';});}
+function scalusTab(id){
+  document.querySelectorAll('.tab-panel').forEach(function(p){p.hidden=(p.id!==id);});
+  document.querySelectorAll('.tab-btn').forEach(function(b){b.classList.toggle('active', b.getAttribute('data-tab')===id);});
+}
+document.querySelectorAll('.tab-btn').forEach(function(b){b.addEventListener('click',function(){scalusTab(b.getAttribute('data-tab'));});});
 document.querySelectorAll('table.sortable thead th').forEach(function(th){
   th.addEventListener('click',function(){
     var ci=Array.prototype.indexOf.call(th.parentNode.children, th);

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -660,11 +660,16 @@ object ProfileFormatter {
         s"${col1.padTo(col1Width, ' ')}  ${count.reverse.padTo(countWidth, ' ').reverse}  ${mem.reverse.padTo(memWidth, ' ').reverse}  ${cpu.reverse.padTo(cpuWidth, ' ').reverse}"
     }
 
-    /** Deterministic HTML anchor id for a `(file, line)` — computed identically in both the By
-      * Source Location table and the Annotated Source view so one can link to the other.
+    /** Deterministic, injection-safe HTML anchor id for a `(file, line)`, computed identically in
+      * the By Source Location table and the Annotated Source view so one can link to the other.
+      *
+      * Output is `loc_<hex>_<line>` — only `[a-z0-9_]`, so it is safe to embed unescaped in both an
+      * `id` attribute and the `onclick` JS string literal; the unescaped call sites rely on that.
+      * Uses a hash of the full path (not a sanitized path) so distinct paths like `a/b.scala` and
+      * `a.b.scala` don't collapse to the same anchor.
       */
     private def locAnchor(file: String, line: Int): String =
-        "loc_" + file.map(c => if c.isLetterOrDigit then c else '_').mkString + "_" + line
+        "loc_" + Integer.toHexString(file.hashCode) + "_" + line
 
     /** Shorten file path to just the filename without extension. */
     private def shortFile(path: String): String = {
@@ -751,9 +756,10 @@ document.addEventListener('click',function(e){
   while(t&&t.nodeType===1){if(t.classList&&t.classList.contains('treenode')){scalusToggle(t);return;}t=t.parentNode;}
 });
 function scalusGoto(anchor){
-  scalusTab('annotated');
   var el=document.getElementById(anchor);
-  if(el){el.scrollIntoView({block:'center'});el.classList.add('hl');setTimeout(function(){el.classList.remove('hl');},1800);}
+  if(!el)return;
+  scalusTab('annotated');
+  el.scrollIntoView({block:'center'});el.classList.add('hl');setTimeout(function(){el.classList.remove('hl');},1800);
 }
 function scalusTab(id){
   document.querySelectorAll('.tab-panel').forEach(function(p){p.hidden=(p.id!==id);});

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -1,8 +1,23 @@
 package scalus.uplc.eval
 
+import scalus.cardano.ledger.{ExUnitPrices, ExUnits}
 import scalus.uplc.builtin.platform
 
 object ProfileFormatter {
+
+    /** On-chain fee (lovelace) for `(mem, cpu)` under `prices`, or `None` when no prices are set.
+      * Reuses the ledger fee formula so it matches what a transaction would actually be charged.
+      */
+    private def feeLovelace(prices: Option[ExUnitPrices], mem: Long, cpu: Long): Option[Long] =
+        prices.map(p => ExUnits(memory = mem, steps = cpu).fee(p).value)
+
+    /** `lovelace` rendered as ADA with 6 decimals, using integer math so the output is independent
+      * of the platform default locale (1 ADA = 1_000_000 lovelace).
+      */
+    private def adaString(lovelace: Long): String = {
+        val frac = (math.abs(lovelace) % 1_000_000L).toString.reverse.padTo(6, '0').reverse
+        s"${lovelace / 1_000_000L}.$frac"
+    }
 
     /** Max rows rendered per HTML table before collapsing into a "… and N more" note. */
     private val htmlRowCap = 200
@@ -135,7 +150,10 @@ object ProfileFormatter {
             if data.transitions.size > effectiveMaxRows then
                 sb.append(s"  ... and ${data.transitions.size - effectiveMaxRows} more\n")
 
-        sb.append(s"\nTotal: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}")
+        val totalFee = feeLovelace(data.prices, data.totalBudget.memory, data.totalBudget.steps)
+            .map(f => s" fee=$f lovelace (${adaString(f)} ADA)")
+            .getOrElse("")
+        sb.append(s"\nTotal: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}$totalFee")
         sb.toString
     }
 
@@ -143,12 +161,20 @@ object ProfileFormatter {
     def summary(data: ProfilingData, topN: Int = 10): String = {
         val n = math.max(1, topN)
         val sb = new StringBuilder
-        sb.append(s"Total: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}\n")
+        // ` fee=<lovelace>` for an entry's (mem, cpu), or "" when no prices are attached.
+        def feeStr(mem: Long, cpu: Long): String =
+            feeLovelace(data.prices, mem, cpu).map(f => s" fee=$f").getOrElse("")
+        sb.append(
+          s"Total: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}${feeStr(data.totalBudget.memory, data.totalBudget.steps)}\n"
+        )
         if data.byFunction.nonEmpty then
             sb.append(s"Top $n by CPU (builtin):\n")
             data.byFunction.sortBy(e => -e.cpu).take(n).foreach { e =>
                 sb.append(
-                  "  " + e.name.padTo(24, ' ') + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}\n"
+                  "  " + e.name.padTo(
+                    24,
+                    ' '
+                  ) + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}${feeStr(e.memory, e.cpu)}\n"
                 )
             }
         if data.bySourceLocation.nonEmpty then
@@ -156,21 +182,39 @@ object ProfileFormatter {
             data.bySourceLocation.sortBy(e => -e.cpu).take(n).foreach { e =>
                 val loc = s"${shortFile(e.file)}:${e.line}"
                 sb.append(
-                  "  " + loc.padTo(24, ' ') + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}\n"
+                  "  " + loc.padTo(
+                    24,
+                    ' '
+                  ) + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}${feeStr(e.memory, e.cpu)}\n"
                 )
             }
         sb.toString
     }
 
-    /** Renders profiling data as CSV (one diffable file across all sections). */
+    /** Renders profiling data as CSV (one diffable file across all sections). When the data carries
+      * execution unit prices, a trailing `fee` column (lovelace) is added.
+      */
     def toCsv(data: ProfilingData): String = {
+        def fee(mem: Long, cpu: Long): Option[Long] = feeLovelace(data.prices, mem, cpu)
         val sb = new StringBuilder
-        sb.append("section,key,detail,count,mem,cpu\n")
+        sb.append(
+          s"section,key,detail,count,mem,cpu${if data.prices.isDefined then ",fee" else ""}\n"
+        )
         data.bySourceLocation.foreach(e =>
-            sb.append(csvRow("location", s"${e.file}:${e.line}", "", e.count, e.memory, e.cpu))
+            sb.append(
+              csvRow(
+                "location",
+                s"${e.file}:${e.line}",
+                "",
+                e.count,
+                e.memory,
+                e.cpu,
+                fee(e.memory, e.cpu)
+              )
+            )
         )
         data.byFunction.foreach(e =>
-            sb.append(csvRow("builtin", e.name, "", e.count, e.memory, e.cpu))
+            sb.append(csvRow("builtin", e.name, "", e.count, e.memory, e.cpu, fee(e.memory, e.cpu)))
         )
         data.byLocationFunction.foreach(e =>
             sb.append(
@@ -180,7 +224,8 @@ object ProfileFormatter {
                 e.functionName,
                 e.count,
                 e.memory,
-                e.cpu
+                e.cpu,
+                fee(e.memory, e.cpu)
               )
             )
         )
@@ -192,20 +237,39 @@ object ProfileFormatter {
                 s"${t.toFile}:${t.toLine}",
                 t.count,
                 0,
-                0
+                0,
+                fee(0, 0)
               )
             )
         )
-        sb.append(csvRow("total", "", "", 0, data.totalBudget.memory, data.totalBudget.steps))
+        sb.append(
+          csvRow(
+            "total",
+            "",
+            "",
+            0,
+            data.totalBudget.memory,
+            data.totalBudget.steps,
+            fee(data.totalBudget.memory, data.totalBudget.steps)
+          )
+        )
         sb.toString
     }
 
-    /** Renders the full profiling data as JSON (machine-readable). */
+    /** Renders the full profiling data as JSON (machine-readable). When the data carries execution
+      * unit prices, every entry and the total also include a derived `"fee"` in lovelace.
+      */
     def toJson(data: ProfilingData): String = {
+        // `,"fee":<lovelace>` for an entry's (mem, cpu), or "" when no prices are attached.
+        def feeJson(mem: Long, cpu: Long): String =
+            feeLovelace(data.prices, mem, cpu).map(f => s""","fee":$f""").getOrElse("")
         val sb = new StringBuilder
         sb.append("{\n")
         sb.append(
-          s"""  "totalBudget": { "mem": ${data.totalBudget.memory}, "cpu": ${data.totalBudget.steps} },\n"""
+          s"""  "totalBudget": { "mem": ${data.totalBudget.memory}, "cpu": ${data.totalBudget.steps}${feeJson(
+                data.totalBudget.memory,
+                data.totalBudget.steps
+              )} },\n"""
         )
         sb.append("  \"bySourceLocation\": [")
         sb.append(
@@ -213,7 +277,10 @@ object ProfileFormatter {
               .map(e =>
                   s"""{"file":"${jsonEsc(
                         e.file
-                      )}","line":${e.line},"count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+                      )}","line":${e.line},"count":${e.count},"mem":${e.memory},"cpu":${e.cpu}${feeJson(
+                        e.memory,
+                        e.cpu
+                      )}}"""
               )
               .mkString(",")
         )
@@ -224,7 +291,10 @@ object ProfileFormatter {
               .map(e =>
                   s"""{"name":"${jsonEsc(
                         e.name
-                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}${feeJson(
+                        e.memory,
+                        e.cpu
+                      )}}"""
               )
               .mkString(",")
         )
@@ -235,7 +305,10 @@ object ProfileFormatter {
               .map(e =>
                   s"""{"file":"${jsonEsc(e.file)}","line":${e.line},"function":"${jsonEsc(
                         e.functionName
-                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}${feeJson(
+                        e.memory,
+                        e.cpu
+                      )}}"""
               )
               .mkString(",")
         )
@@ -270,8 +343,15 @@ object ProfileFormatter {
       * @param sources
       *   optional `file -> source lines` (line `n` is element `n - 1`); profiled files present here
       *   are rendered with per-line cost annotations
+      * @param title
+      *   optional label identifying what was profiled (e.g. the contract and test-case name). When
+      *   non-empty it is shown in the page `<title>` and as a subtitle above the report.
       */
-    def toHtml(data: ProfilingData, sources: Map[String, IndexedSeq[String]]): String = {
+    def toHtml(
+        data: ProfilingData,
+        sources: Map[String, IndexedSeq[String]],
+        title: String = ""
+    ): String = {
         val totalCpu = math.max(1L, data.totalBudget.steps)
 
         // Build each section's inner HTML; only non-empty sections become tabs. Section titles
@@ -296,7 +376,8 @@ object ProfileFormatter {
             _,
             Seq("Builtin"),
             data.byFunction.map(e => (Seq(e.name), e.count, e.memory, e.cpu)),
-            totalCpu
+            totalCpu,
+            data.prices
           )
         )
 
@@ -313,7 +394,8 @@ object ProfileFormatter {
                       e.cpu
                     )
                 ),
-                totalCpu
+                totalCpu,
+                data.prices
               )
             )
 
@@ -322,13 +404,20 @@ object ProfileFormatter {
             section("edges", "Hot Edges")(appendHotEdges(_, data))
 
         val sb = new StringBuilder
+        val pageTitle =
+            if title.isEmpty then "Scalus Profile" else s"Scalus Profile — ${escapeHtml(title)}"
         sb.append(
-          "<!DOCTYPE html>\n<html><head><meta charset=\"utf-8\"><title>Scalus Profile</title>\n<style>\n"
+          s"""<!DOCTYPE html>\n<html><head><meta charset="utf-8"><title>$pageTitle</title>\n<style>\n"""
         )
         sb.append(htmlStyle)
         sb.append("\n</style></head><body>\n<h1>Scalus CEK Machine Profile</h1>\n")
+        if title.nonEmpty then sb.append(s"""<p class="subtitle">${escapeHtml(title)}</p>\n""")
+        val totalFeeStr =
+            feeLovelace(data.prices, data.totalBudget.memory, data.totalBudget.steps)
+                .map(f => s", fee=$f lovelace (${adaString(f)} ADA)")
+                .getOrElse("")
         sb.append(
-          s"""<p class="summary">Total budget: mem=${data.totalBudget.memory}, cpu=${data.totalBudget.steps}</p>\n"""
+          s"""<p class="summary">Total budget: mem=${data.totalBudget.memory}, cpu=${data.totalBudget.steps}$totalFeeStr</p>\n"""
         )
         sb.append(
           "<input id=\"filter\" class=\"filter\" placeholder=\"filter rows by text…\" oninput=\"scalusFilter(this.value)\">\n"
@@ -383,13 +472,17 @@ object ProfileFormatter {
       *
       * @param include
       *   source-file filter for the annotated-source view (see [[loadSources]])
+      * @param title
+      *   optional label identifying what was profiled (e.g. the contract and test-case name); shown
+      *   in the page `<title>` and as a subtitle above the report (see [[toHtml]])
       */
     def writeHtml(
         data: ProfilingData,
         path: String,
-        include: String => Boolean = _ => true
+        include: String => Boolean = _ => true,
+        title: String = ""
     ): Unit =
-        writeTo(path, toHtml(data, loadSources(data, include)))
+        writeTo(path, toHtml(data, loadSources(data, include), title))
 
     /** Write the CSV rendering to `path` (creating parent dirs). */
     def writeCsv(data: ProfilingData, path: String): Unit = writeTo(path, toCsv(data))
@@ -461,8 +554,9 @@ object ProfileFormatter {
             sb.append("};\n</script>\n")
 
             val maxCpu = math.max(1L, rows.map(_.cpu).max)
+            val feeHeader = if data.prices.isDefined then "<th>Fee (lov)</th>" else ""
             sb.append(
-              "<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th><th>%cpu</th></tr></thead><tbody>\n"
+              s"<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th>$feeHeader<th>%cpu</th></tr></thead><tbody>\n"
             )
             rows.take(htmlRowCap).foreach { e =>
                 val loc = s"${shortFile(e.file)}:${e.line}"
@@ -485,8 +579,10 @@ object ProfileFormatter {
                                 )}</span><div class="subtree" hidden></div>"""
                 val pct = oneDecimalPct(e.cpu, totalCpu)
                 val barW = (e.cpu * 120 / maxCpu).toInt
+                val feeCell =
+                    feeLovelace(data.prices, e.memory, e.cpu).map(f => s"<td>$f</td>").getOrElse("")
                 sb.append(
-                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>" +
+                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>$feeCell" +
                       s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td></tr>\n"
                 )
             }
@@ -500,15 +596,17 @@ object ProfileFormatter {
         sb: StringBuilder,
         labelHeaders: Seq[String],
         rows: Seq[(Seq[String], Long, Long, Long)],
-        totalCpu: Long
+        totalCpu: Long,
+        prices: Option[ExUnitPrices]
     ): Unit = {
         if rows.isEmpty then sb.append("<p>(none recorded)</p>\n")
         else
             val maxCpu = math.max(1L, rows.map(_._4).max)
+            val feeHeader = if prices.isDefined then "<th>Fee (lov)</th>" else ""
             sb.append("<table class=\"sortable\"><thead><tr>")
             labelHeaders.foreach(h => sb.append(s"<th>${escapeHtml(h)}</th>"))
             sb.append(
-              "<th>Count</th><th>Memory</th><th>CPU</th><th>%cpu</th></tr></thead><tbody>\n"
+              s"<th>Count</th><th>Memory</th><th>CPU</th>$feeHeader<th>%cpu</th></tr></thead><tbody>\n"
             )
             rows.take(htmlRowCap).foreach { case (labels, count, mem, cpu) =>
                 val pct = oneDecimalPct(cpu, totalCpu)
@@ -516,6 +614,7 @@ object ProfileFormatter {
                 sb.append("<tr>")
                 labels.foreach(l => sb.append(s"<td>${escapeHtml(l)}</td>"))
                 sb.append(s"<td>$count</td><td>$mem</td><td>$cpu</td>")
+                feeLovelace(prices, mem, cpu).foreach(f => sb.append(s"<td>$f</td>"))
                 sb.append(s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td>")
                 sb.append("</tr>\n")
             }
@@ -551,7 +650,12 @@ object ProfileFormatter {
                     if cpu == 0 then ""
                     else
                         s" style='background:rgba(220,40,40,${0.08 + 0.5 * (cpu.toDouble / maxCpu)})'"
-                val gut = if cpu == 0 then "" else s"$cpu cpu / $mem mem / $cnt×"
+                val gut =
+                    if cpu == 0 then ""
+                    else
+                        val feeStr =
+                            feeLovelace(data.prices, mem, cpu).map(f => s" / $f lov").getOrElse("")
+                        s"$cpu cpu / $mem mem / $cnt×$feeStr"
                 // Anchor profiled lines so the By Source Location tab can jump straight here.
                 val anchor = if e.isDefined then s" id=\"${locAnchor(file, ln)}\"" else ""
                 sb.append(
@@ -627,9 +731,12 @@ object ProfileFormatter {
         detail: String,
         count: Long,
         mem: Long,
-        cpu: Long
+        cpu: Long,
+        fee: Option[Long]
     ): String =
-        s"${csvEscape(section)},${csvEscape(key)},${csvEscape(detail)},$count,$mem,$cpu\n"
+        s"${csvEscape(section)},${csvEscape(key)},${csvEscape(detail)},$count,$mem,$cpu${fee
+                .map(f => s",$f")
+                .getOrElse("")}\n"
 
     private def csvEscape(s: String): String =
         if s.exists(c => c == ',' || c == '"' || c == '\n' || c == '\r') then
@@ -702,6 +809,7 @@ thead th:hover { background: #e0e8f0; }
 tbody tr:hover { background: #e8f4fd; }
 .bar { display: inline-block; height: 10px; background: #4a90d9; vertical-align: middle; }
 .summary { font-size: 1.1em; margin: 10px 0; }
+.subtitle { font-size: 1.25em; font-weight: 600; color: #2a5b8c; margin: -6px 0 8px; }
 table.matrix td { min-width: 22px; text-align: center; }
 table.matrix th.rowhdr { text-align: left; font-weight: normal; }
 ol.legend { color: #555; font-size: 0.9em; }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -372,7 +372,9 @@ object ProfileFormatter {
             .distinct
             .filter(include)
             .filter(platform.fileExists)
-            .map(f => f -> new String(platform.readFile(f), "UTF-8").split('\n').toIndexedSeq)
+            .map(f =>
+                f -> new String(platform.readFile(f), "UTF-8").split("\r?\n", -1).toIndexedSeq
+            )
             .toMap
 
     /** Write a self-contained, source-annotated HTML report to `path` (creating parent dirs).
@@ -434,6 +436,9 @@ object ProfileFormatter {
                     .toMap
 
             // Embed the graph as JS data (labels + incoming adjacency) for lazy expansion.
+            // Labels are escapeHtml'd (so they are safe both inside this inline <script> — no
+            // </script> breakout — and when the JS re-inserts them via innerHTML, which decodes the
+            // entities) then jsonEsc'd (valid JS string literal). Ids/counts are integers.
             sb.append("<script>\nvar SCALUS_LABEL={")
             sb.append(
               allLocs.zipWithIndex
@@ -466,7 +471,7 @@ object ProfileFormatter {
                         s"""<span class="treenode" data-id="$id" data-path=""><span class="mark">▶</span> ${escapeHtml(
                               loc
                             )}</span><div class="subtree" hidden></div>"""
-                val pct = f"${e.cpu * 100.0 / totalCpu}%.1f"
+                val pct = oneDecimalPct(e.cpu, totalCpu)
                 val barW = (e.cpu * 120 / maxCpu).toInt
                 sb.append(
                   s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>" +
@@ -494,7 +499,7 @@ object ProfileFormatter {
               "<th>Count</th><th>Memory</th><th>CPU</th><th>%cpu</th></tr></thead><tbody>\n"
             )
             rows.take(htmlRowCap).foreach { case (labels, count, mem, cpu) =>
-                val pct = f"${cpu * 100.0 / totalCpu}%.1f"
+                val pct = oneDecimalPct(cpu, totalCpu)
                 val barW = (cpu * 120 / maxCpu).toInt
                 sb.append("<tr>")
                 labels.foreach(l => sb.append(s"<td>${escapeHtml(l)}</td>"))
@@ -651,6 +656,14 @@ object ProfileFormatter {
 
     private def escapeHtml(s: String): String =
         s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    /** `num/denom` as a percentage with one decimal, computed with integer math so the result is
+      * independent of the platform default locale (`f"%.1f"` would emit `,` on e.g. de_DE and break
+      * the rendered tables / CSS).
+      */
+    private def oneDecimalPct(num: Long, denom: Long): String =
+        val permille = if denom <= 0 then 0L else num * 1000 / denom
+        s"${permille / 10}.${permille % 10}"
 
     private val htmlStyle: String =
         """body { font-family: monospace; margin: 20px; background: #fafafa; color: #222; }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -483,6 +483,10 @@ object ProfileFormatter {
           appendSourceLocationTable(_, data, totalCpu, sources.keySet, incl)
         )
 
+        renderHotPaths(data, sources.keySet).foreach(html =>
+            sections += (("hotpaths", "Hot Paths", html))
+        )
+
         renderAnnotatedSource(data, sources).foreach(html =>
             sections += (("annotated", "Annotated Source", html))
         )
@@ -837,6 +841,83 @@ object ProfileFormatter {
             sb.append(s"<p>… and ${data.transitions.size - htmlRowCap} more edges</p>\n")
     }
 
+    /** "Hot Paths": where the budget flows from the program entry, as a bounded tree of the
+      * heaviest call edges. Grown best-first (heaviest edge first) from `data.entry` up to a node
+      * cap, so it branches — showing the several hot paths, not a single spine. Each node is
+      * reached via its heaviest incoming edge (cycles add a node once), and each edge is labelled
+      * with the cost it carries (the [[edgeCosts]] estimate, fee when priced). Anchoring at the
+      * real entry keeps the contract's own code at the root; descending by per-edge cost sidesteps
+      * the share-dilution that makes a node's *total* inclusive cost a poor guide here.
+      */
+    private def renderHotPaths(data: ProfilingData, contractFiles: Set[String]): Option[String] = {
+        // Root at the first executed location that belongs to a contract file (so the contract's own
+        // entry is the root, not the framework/annotation-fallback step that happens to run first);
+        // fall back to the literal first step when no contract files are known.
+        val entry = data.entryTrace
+            .find(n => contractFiles.contains(n._1))
+            .orElse(data.entryTrace.headOption)
+            .getOrElse(return None)
+        val unit = if data.prices.isDefined then "lov" else "cpu"
+        val adj = scala.collection.mutable.HashMap[
+          (String, Int),
+          scala.collection.mutable.ArrayBuffer[((String, Int), Long)]
+        ]()
+        edgeCosts(data).foreach { case (t, mem, cpu) =>
+            val c = feeLovelace(data.prices, mem, cpu).getOrElse(cpu)
+            if c > 0 then
+                adj.getOrElseUpdate(
+                  (t.fromFile, t.fromLine),
+                  scala.collection.mutable.ArrayBuffer()
+                )
+                    += (((t.toFile, t.toLine), c))
+        }
+        if !adj.contains(entry) then return None
+        val selfOf = data.bySourceLocation
+            .map(e =>
+                (e.file, e.line) -> feeLovelace(data.prices, e.memory, e.cpu).getOrElse(e.cpu)
+            )
+            .toMap
+
+        val maxNodes = 40
+        val inTree = scala.collection.mutable.HashSet[(String, Int)](entry)
+        val children =
+            scala.collection.mutable.HashMap[
+              (String, Int),
+              scala.collection.mutable.ArrayBuffer[((String, Int), Long)]
+            ]()
+        // Best-first: always grow the heaviest pending edge whose source is already in the tree.
+        val pq = scala.collection.mutable.PriorityQueue
+            .empty[(Long, (String, Int), (String, Int))](Ordering.by(_._1))
+        adj(entry).foreach { case (to, c) => pq.enqueue((c, entry, to)) }
+        while inTree.size < maxNodes && pq.nonEmpty do
+            val (c, from, to) = pq.dequeue()
+            if !inTree.contains(to) then
+                inTree += to
+                children.getOrElseUpdate(from, scala.collection.mutable.ArrayBuffer()) += ((to, c))
+                adj.getOrElse(to, Nil).foreach { case (t2, c2) =>
+                    if !inTree.contains(t2) then pq.enqueue((c2, to, t2))
+                }
+
+        val sb = new StringBuilder
+        sb.append(
+          s"<p>Where the budget flows from the program entry: the heaviest call edges (cost in $unit carried by each call), branching to show the top paths.</p>\n"
+        )
+        def renderNode(node: (String, Int), carried: String): Unit = {
+            val loc = escapeHtml(s"${shortFile(node._1)}:${node._2}")
+            sb.append(s"<li><span class='loc'>$loc</span> <span class='c'>$carried</span>")
+            children.get(node).foreach { cs =>
+                sb.append("<ul>")
+                cs.sortBy(-_._2).foreach((ch, c) => renderNode(ch, s"· $c $unit"))
+                sb.append("</ul>")
+            }
+            sb.append("</li>\n")
+        }
+        sb.append("<ul class='hottree'>\n")
+        renderNode(entry, s"(entry, self ${selfOf.getOrElse(entry, 0L)} $unit)")
+        sb.append("</ul>\n")
+        Some(sb.toString)
+    }
+
     private def csvRow(
         section: String,
         key: String,
@@ -922,6 +1003,11 @@ tbody tr:hover { background: #e8f4fd; }
 .bar { display: inline-block; height: 10px; background: #4a90d9; vertical-align: middle; }
 .summary { font-size: 1.1em; margin: 10px 0; }
 .subtitle { font-size: 1.25em; font-weight: 600; color: #2a5b8c; margin: -6px 0 8px; }
+.hottree, .hottree ul { list-style: none; padding-left: 0; }
+.hottree ul { margin-left: 12px; border-left: 1px solid #ddd; padding-left: 10px; }
+.hottree li { margin: 2px 0; }
+.hottree .loc { font-weight: 600; }
+.hottree .c { color: #b5651d; margin-left: 6px; }
 table.src { border: none; width: 100%; }
 table.src td { border: none; padding: 0 8px; }
 table.src td.ln { color: #999; text-align: right; user-select: none; }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -2,6 +2,12 @@ package scalus.uplc.eval
 
 object ProfileFormatter {
 
+    /** Max rows rendered per HTML table before collapsing into a "… and N more" note. */
+    private val htmlRowCap = 200
+
+    /** Max locations shown on each axis of the transition matrix (keeps it readable). */
+    private val matrixCap = 24
+
     /** Renders profiling data as a formatted text table.
       *
       * @param data
@@ -128,68 +134,339 @@ object ProfileFormatter {
         sb.toString
     }
 
-    /** Renders profiling data as a self-contained HTML page. */
-    def toHtml(data: ProfilingData): String = {
+    /** Compact summary suitable for console / log output: total budget plus the top-N by CPU. */
+    def summary(data: ProfilingData, topN: Int = 10): String = {
+        val n = math.max(1, topN)
         val sb = new StringBuilder
-        sb.append("""<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Scalus Profile</title>
-<style>
-body { font-family: monospace; margin: 20px; background: #fafafa; }
-h2 { color: #333; }
-table { border-collapse: collapse; margin-bottom: 20px; }
-th, td { padding: 4px 12px; text-align: right; border: 1px solid #ddd; }
-th { background: #f0f0f0; }
-td:first-child, th:first-child { text-align: left; }
-tr:hover { background: #e8f4fd; }
-.bar { display: inline-block; height: 12px; background: #4a90d9; vertical-align: middle; }
-.summary { font-size: 1.1em; margin: 10px 0; }
-</style></head><body>
-<h1>Scalus CEK Machine Profile</h1>
-""")
+        sb.append(s"Total: mem=${data.totalBudget.memory} cpu=${data.totalBudget.steps}\n")
+        if data.byFunction.nonEmpty then
+            sb.append(s"Top $n by CPU (function):\n")
+            data.byFunction.sortBy(e => -e.cpu).take(n).foreach { e =>
+                sb.append(
+                  "  " + e.name.padTo(24, ' ') + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}\n"
+                )
+            }
+        if data.bySourceLocation.nonEmpty then
+            sb.append(s"Top $n by CPU (source):\n")
+            data.bySourceLocation.sortBy(e => -e.cpu).take(n).foreach { e =>
+                val loc = s"${shortFile(e.file)}:${e.line}"
+                sb.append(
+                  "  " + loc.padTo(24, ' ') + s" cpu=${e.cpu} mem=${e.memory} n=${e.count}\n"
+                )
+            }
+        sb.toString
+    }
+
+    /** Renders profiling data as CSV (one diffable file across all sections). */
+    def toCsv(data: ProfilingData): String = {
+        val sb = new StringBuilder
+        sb.append("section,key,detail,count,mem,cpu\n")
+        data.bySourceLocation.foreach(e =>
+            sb.append(csvRow("location", s"${e.file}:${e.line}", "", e.count, e.memory, e.cpu))
+        )
+        data.byFunction.foreach(e =>
+            sb.append(csvRow("function", e.name, "", e.count, e.memory, e.cpu))
+        )
+        data.byLocationFunction.foreach(e =>
+            sb.append(
+              csvRow("builtin", s"${e.file}:${e.line}", e.functionName, e.count, e.memory, e.cpu)
+            )
+        )
+        data.transitions.foreach(t =>
+            sb.append(
+              csvRow(
+                "edge",
+                s"${t.fromFile}:${t.fromLine}",
+                s"${t.toFile}:${t.toLine}",
+                t.count,
+                0,
+                0
+              )
+            )
+        )
+        sb.append(csvRow("total", "", "", 0, data.totalBudget.memory, data.totalBudget.steps))
+        sb.toString
+    }
+
+    /** Renders the full profiling data as JSON (machine-readable). */
+    def toJson(data: ProfilingData): String = {
+        val sb = new StringBuilder
+        sb.append("{\n")
+        sb.append(
+          s"""  "totalBudget": { "mem": ${data.totalBudget.memory}, "cpu": ${data.totalBudget.steps} },\n"""
+        )
+        sb.append("  \"bySourceLocation\": [")
+        sb.append(
+          data.bySourceLocation
+              .map(e =>
+                  s"""{"file":"${jsonEsc(
+                        e.file
+                      )}","line":${e.line},"count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+              )
+              .mkString(",")
+        )
+        sb.append("],\n")
+        sb.append("  \"byFunction\": [")
+        sb.append(
+          data.byFunction
+              .map(e =>
+                  s"""{"name":"${jsonEsc(
+                        e.name
+                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+              )
+              .mkString(",")
+        )
+        sb.append("],\n")
+        sb.append("  \"byLocationFunction\": [")
+        sb.append(
+          data.byLocationFunction
+              .map(e =>
+                  s"""{"file":"${jsonEsc(e.file)}","line":${e.line},"function":"${jsonEsc(
+                        e.functionName
+                      )}","count":${e.count},"mem":${e.memory},"cpu":${e.cpu}}"""
+              )
+              .mkString(",")
+        )
+        sb.append("],\n")
+        sb.append("  \"transitions\": [")
+        sb.append(
+          data.transitions
+              .map(t =>
+                  s"""{"fromFile":"${jsonEsc(
+                        t.fromFile
+                      )}","fromLine":${t.fromLine},"toFile":"${jsonEsc(
+                        t.toFile
+                      )}","toLine":${t.toLine},"count":${t.count}}"""
+              )
+              .mkString(",")
+        )
+        sb.append("]\n}\n")
+        sb.toString
+    }
+
+    /** Renders profiling data as a self-contained HTML page (no source annotation). */
+    def toHtml(data: ProfilingData): String = toHtml(data, Map.empty)
+
+    /** Renders profiling data as a self-contained, interactive HTML page.
+      *
+      * The page bundles its own CSS/JS (no external dependencies): sortable, filterable tables with
+      * %-of-CPU bars, a transition matrix heatmap with a hot-edges table, and — when source text is
+      * supplied — a per-line cost-annotated source view (the flagship view).
+      *
+      * @param data
+      *   the profiling data
+      * @param sources
+      *   optional `file -> source lines` (line `n` is element `n - 1`); profiled files present here
+      *   are rendered with per-line cost annotations
+      */
+    def toHtml(data: ProfilingData, sources: Map[String, IndexedSeq[String]]): String = {
+        val totalCpu = math.max(1L, data.totalBudget.steps)
+        val sb = new StringBuilder
+        sb.append(
+          "<!DOCTYPE html>\n<html><head><meta charset=\"utf-8\"><title>Scalus Profile</title>\n<style>\n"
+        )
+        sb.append(htmlStyle)
+        sb.append("\n</style></head><body>\n<h1>Scalus CEK Machine Profile</h1>\n")
         sb.append(
           s"""<p class="summary">Total budget: mem=${data.totalBudget.memory}, cpu=${data.totalBudget.steps}</p>\n"""
         )
+        sb.append(
+          "<input id=\"filter\" class=\"filter\" placeholder=\"filter rows by text…\" oninput=\"scalusFilter(this.value)\">\n"
+        )
 
-        // By Source Location
         sb.append("<h2>By Source Location</h2>\n")
-        if data.bySourceLocation.isEmpty then sb.append("<p>No source locations recorded.</p>\n")
-        else
-            val maxMem =
-                math.max(1L, data.bySourceLocation.headOption.map(_.memory).getOrElse(1L))
-            sb.append(
-              "<table><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th><th></th></tr>\n"
-            )
-            data.bySourceLocation.foreach { e =>
-                val barWidth = (e.memory * 100 / maxMem).toInt
-                sb.append(
-                  s"""<tr><td>${escapeHtml(
-                        e.file
-                      )}:${e.line}</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td><td><span class="bar" style="width:${barWidth}px"></span></td></tr>\n"""
-                )
-            }
-            sb.append("</table>\n")
+        appendCostTable(
+          sb,
+          Seq("Location"),
+          data.bySourceLocation.map(e =>
+              (Seq(s"${shortFile(e.file)}:${e.line}"), e.count, e.memory, e.cpu)
+          ),
+          totalCpu
+        )
 
-        // By Function
+        appendAnnotatedSource(sb, data, sources)
+
         sb.append("<h2>By Function</h2>\n")
-        if data.byFunction.isEmpty then sb.append("<p>No functions recorded.</p>\n")
-        else
-            val maxMem = math.max(1L, data.byFunction.headOption.map(_.memory).getOrElse(1L))
-            sb.append(
-              "<table><tr><th>Function</th><th>Count</th><th>Memory</th><th>CPU</th><th></th></tr>\n"
-            )
-            data.byFunction.foreach { e =>
-                val barWidth = (e.memory * 100 / maxMem).toInt
-                sb.append(
-                  s"""<tr><td>${escapeHtml(
-                        e.name
-                      )}</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td><td><span class="bar" style="width:${barWidth}px"></span></td></tr>\n"""
-                )
-            }
-            sb.append("</table>\n")
+        appendCostTable(
+          sb,
+          Seq("Function"),
+          data.byFunction.map(e => (Seq(e.name), e.count, e.memory, e.cpu)),
+          totalCpu
+        )
 
-        sb.append("</body></html>")
+        if data.byLocationFunction.nonEmpty then
+            sb.append("<h2>Builtins by Source Location</h2>\n")
+            appendCostTable(
+              sb,
+              Seq("Location", "Function"),
+              data.byLocationFunction.map(e =>
+                  (Seq(s"${shortFile(e.file)}:${e.line}", e.functionName), e.count, e.memory, e.cpu)
+              ),
+              totalCpu
+            )
+
+        if data.transitions.nonEmpty then
+            appendTransitionMatrix(sb, data)
+            appendHotEdges(sb, data)
+
+        sb.append("<script>\n")
+        sb.append(htmlScript)
+        sb.append("\n</script>\n</body></html>")
         sb.toString
     }
+
+    /** A sortable/filterable cost table: label column(s) + count, mem, cpu and a %-of-CPU bar. */
+    private def appendCostTable(
+        sb: StringBuilder,
+        labelHeaders: Seq[String],
+        rows: Seq[(Seq[String], Long, Long, Long)],
+        totalCpu: Long
+    ): Unit = {
+        if rows.isEmpty then sb.append("<p>(none recorded)</p>\n")
+        else
+            val maxCpu = math.max(1L, rows.map(_._4).max)
+            sb.append("<table class=\"sortable\"><thead><tr>")
+            labelHeaders.foreach(h => sb.append(s"<th>${escapeHtml(h)}</th>"))
+            sb.append(
+              "<th>Count</th><th>Memory</th><th>CPU</th><th>%cpu</th></tr></thead><tbody>\n"
+            )
+            rows.take(htmlRowCap).foreach { case (labels, count, mem, cpu) =>
+                val pct = f"${cpu * 100.0 / totalCpu}%.1f"
+                val barW = (cpu * 120 / maxCpu).toInt
+                sb.append("<tr>")
+                labels.foreach(l => sb.append(s"<td>${escapeHtml(l)}</td>"))
+                sb.append(s"<td>$count</td><td>$mem</td><td>$cpu</td>")
+                sb.append(s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td>")
+                sb.append("</tr>\n")
+            }
+            sb.append("</tbody></table>\n")
+            if rows.size > htmlRowCap then
+                sb.append(s"<p>… and ${rows.size - htmlRowCap} more rows</p>\n")
+    }
+
+    /** Per-line cost-annotated source: each line shown with its cpu/mem/count and a heat background
+      * proportional to its share of the file's CPU. Only files present in `sources` are rendered.
+      */
+    private def appendAnnotatedSource(
+        sb: StringBuilder,
+        data: ProfilingData,
+        sources: Map[String, IndexedSeq[String]]
+    ): Unit = {
+        if sources.isEmpty then return
+        val byFile = data.bySourceLocation.groupBy(_.file)
+        val files =
+            sources.keys.filter(byFile.contains).toSeq.sortBy(f => -byFile(f).map(_.cpu).sum)
+        if files.isEmpty then return
+        sb.append("<h2>Annotated Source</h2>\n")
+        files.foreach { file =>
+            val lines = sources(file)
+            val perLine = byFile(file).map(e => e.line -> e).toMap
+            val maxCpu = math.max(1L, byFile(file).map(_.cpu).max)
+            sb.append(s"<h3>${escapeHtml(file)}</h3>\n<table class='src'>\n")
+            lines.zipWithIndex.foreach { case (text, i) =>
+                val ln = i + 1
+                val e = perLine.get(ln)
+                val cpu = e.map(_.cpu).getOrElse(0L)
+                val mem = e.map(_.memory).getOrElse(0L)
+                val cnt = e.map(_.count).getOrElse(0L)
+                val rowStyle =
+                    if cpu == 0 then ""
+                    else
+                        s" style='background:rgba(220,40,40,${0.08 + 0.5 * (cpu.toDouble / maxCpu)})'"
+                val gut = if cpu == 0 then "" else s"$cpu cpu / $mem mem / $cnt×"
+                sb.append(
+                  s"<tr$rowStyle><td class='ln'>$ln</td><td class='cost'>$gut</td><td class='code'>${escapeHtml(text)}</td></tr>\n"
+                )
+            }
+            sb.append("</table>\n")
+        }
+    }
+
+    /** Transition matrix heatmap: top-N locations by CPU on each axis; cell = transition count. */
+    private def appendTransitionMatrix(sb: StringBuilder, data: ProfilingData): Unit = {
+        val byLocCpu = data.bySourceLocation.map(e => (e.file, e.line) -> e.cpu).toMap
+        val nodes = data.transitions
+            .flatMap(t => Seq((t.fromFile, t.fromLine), (t.toFile, t.toLine)))
+            .distinct
+            .sortBy(loc => -byLocCpu.getOrElse(loc, 0L))
+            .take(matrixCap)
+        if nodes.isEmpty then return
+        val idx = nodes.zipWithIndex.toMap
+        val cells = scala.collection.mutable.HashMap[(Int, Int), Long]()
+        var maxCount = 1L
+        data.transitions.foreach { t =>
+            for fi <- idx.get((t.fromFile, t.fromLine)); ti <- idx.get((t.toFile, t.toLine)) do
+                val v = cells.getOrElse((fi, ti), 0L) + t.count
+                cells((fi, ti)) = v
+                if v > maxCount then maxCount = v
+        }
+        sb.append("<h2>Transition Matrix</h2>\n")
+        sb.append(
+          s"<p>Top ${nodes.size} locations by CPU; cell = transition count (row = from, column = to).</p>\n"
+        )
+        sb.append("<table class='matrix'><tr><th>from \\ to</th>")
+        nodes.indices.foreach(i => sb.append(s"<th>${i + 1}</th>"))
+        sb.append("</tr>\n")
+        nodes.zipWithIndex.foreach { case (loc, ri) =>
+            sb.append(
+              s"<tr><th class='rowhdr'>${ri + 1}. ${escapeHtml(shortFile(loc._1))}:${loc._2}</th>"
+            )
+            nodes.indices.foreach { ci =>
+                val v = cells.getOrElse((ri, ci), 0L)
+                val style =
+                    if v == 0 then ""
+                    else
+                        s" style='background:rgba(40,120,220,${0.1 + 0.7 * (v.toDouble / maxCount)})'"
+                sb.append(s"<td$style>${if v == 0 then "" else v.toString}</td>")
+            }
+            sb.append("</tr>\n")
+        }
+        sb.append("</table>\n<ol class='legend'>\n")
+        nodes.foreach(loc => sb.append(s"<li>${escapeHtml(shortFile(loc._1))}:${loc._2}</li>\n"))
+        sb.append("</ol>\n")
+    }
+
+    /** Sortable hot-edges table (from → to, count), the full edge list behind the matrix. */
+    private def appendHotEdges(sb: StringBuilder, data: ProfilingData): Unit = {
+        sb.append("<h2>Hot Edges</h2>\n")
+        sb.append(
+          "<table class='sortable'><thead><tr><th>From</th><th>To</th><th>Count</th></tr></thead><tbody>\n"
+        )
+        data.transitions.take(htmlRowCap).foreach { t =>
+            sb.append(
+              s"<tr><td>${escapeHtml(shortFile(t.fromFile))}:${t.fromLine}</td><td>${escapeHtml(shortFile(t.toFile))}:${t.toLine}</td><td>${t.count}</td></tr>\n"
+            )
+        }
+        sb.append("</tbody></table>\n")
+        if data.transitions.size > htmlRowCap then
+            sb.append(s"<p>… and ${data.transitions.size - htmlRowCap} more edges</p>\n")
+    }
+
+    private def csvRow(
+        section: String,
+        key: String,
+        detail: String,
+        count: Long,
+        mem: Long,
+        cpu: Long
+    ): String =
+        s"${csvEscape(section)},${csvEscape(key)},${csvEscape(detail)},$count,$mem,$cpu\n"
+
+    private def csvEscape(s: String): String =
+        if s.exists(c => c == ',' || c == '"' || c == '\n' || c == '\r') then
+            "\"" + s.replace("\"", "\"\"") + "\""
+        else s
+
+    private def jsonEsc(s: String): String =
+        s.flatMap {
+            case '"'          => "\\\""
+            case '\\'         => "\\\\"
+            case '\n'         => "\\n"
+            case '\r'         => "\\r"
+            case '\t'         => "\\t"
+            case c if c < ' ' => "\\u%04x".format(c.toInt)
+            case c            => c.toString
+        }
 
     private def formatRow(
         col1: String,
@@ -214,4 +491,45 @@ tr:hover { background: #e8f4fd; }
 
     private def escapeHtml(s: String): String =
         s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    private val htmlStyle: String =
+        """body { font-family: monospace; margin: 20px; background: #fafafa; color: #222; }
+h1 { font-size: 1.4em; } h2 { color: #333; margin-top: 1.4em; } h3 { color: #555; margin: 0.6em 0 0.2em; }
+.filter { width: 320px; padding: 4px 8px; margin: 8px 0; font-family: monospace; }
+table { border-collapse: collapse; margin-bottom: 12px; }
+th, td { padding: 3px 10px; text-align: right; border: 1px solid #ddd; }
+td:first-child, th:first-child { text-align: left; }
+thead th { background: #f0f0f0; cursor: pointer; user-select: none; }
+thead th:hover { background: #e0e8f0; }
+tbody tr:hover { background: #e8f4fd; }
+.bar { display: inline-block; height: 10px; background: #4a90d9; vertical-align: middle; }
+.summary { font-size: 1.1em; margin: 10px 0; }
+table.matrix td { min-width: 22px; text-align: center; }
+table.matrix th.rowhdr { text-align: left; font-weight: normal; }
+ol.legend { color: #555; font-size: 0.9em; }
+table.src { border: none; width: 100%; }
+table.src td { border: none; padding: 0 8px; }
+table.src td.ln { color: #999; text-align: right; user-select: none; }
+table.src td.cost { color: #b00; text-align: right; white-space: nowrap; }
+table.src td.code { text-align: left; white-space: pre; }"""
+
+    private val htmlScript: String =
+        """function scalusFilter(q){q=(q||'').toLowerCase();document.querySelectorAll('table.sortable tbody tr').forEach(function(tr){tr.style.display=tr.textContent.toLowerCase().indexOf(q)>=0?'':'none';});}
+document.querySelectorAll('table.sortable thead th').forEach(function(th){
+  th.addEventListener('click',function(){
+    var ci=Array.prototype.indexOf.call(th.parentNode.children, th);
+    var tb=th.closest('table').querySelector('tbody');
+    var rows=Array.prototype.slice.call(tb.querySelectorAll('tr'));
+    var asc=th.getAttribute('data-asc')!=='1';
+    th.setAttribute('data-asc',asc?'1':'0');
+    rows.sort(function(a,b){
+      var x=((a.children[ci]||{}).textContent||'').trim();
+      var y=((b.children[ci]||{}).textContent||'').trim();
+      var nx=parseFloat(x.replace(/[^0-9.\-]/g,'')), ny=parseFloat(y.replace(/[^0-9.\-]/g,''));
+      var c=(!isNaN(nx)&&!isNaN(ny))?(nx-ny):(x<y?-1:(x>y?1:0));
+      return asc?c:-c;
+    });
+    rows.forEach(function(r){tb.appendChild(r);});
+  });
+});"""
 }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -283,7 +283,9 @@ object ProfileFormatter {
             sections += ((id, title, b.toString))
         }
 
-        section("src", "By Source Location")(appendSourceLocationTable(_, data, totalCpu))
+        section("src", "By Source Location")(
+          appendSourceLocationTable(_, data, totalCpu, sources.keySet)
+        )
 
         renderAnnotatedSource(data, sources).foreach(html =>
             sections += (("annotated", "Annotated Source", html))
@@ -411,7 +413,8 @@ object ProfileFormatter {
     private def appendSourceLocationTable(
         sb: StringBuilder,
         data: ProfilingData,
-        totalCpu: Long
+        totalCpu: Long,
+        annotatedFiles: Set[String]
     ): Unit = {
         val rows = data.bySourceLocation
         if rows.isEmpty then sb.append("<p>(none recorded)</p>\n")
@@ -465,12 +468,21 @@ object ProfileFormatter {
                 val loc = s"${shortFile(e.file)}:${e.line}"
                 val id = idOf((e.file, e.line))
                 val hasIncoming = inByDest.get(id).exists(_.nonEmpty)
+                // Jump to this line in the Annotated Source tab (only when its source is annotated).
+                val goto =
+                    if annotatedFiles.contains(e.file) then
+                        s"""<a class="goto" title="show in Annotated Source" onclick="scalusGoto('${locAnchor(
+                              e.file,
+                              e.line
+                            )}')">⇲</a> """
+                    else ""
                 val locCell =
-                    if !hasIncoming then escapeHtml(loc)
+                    if !hasIncoming then goto + escapeHtml(loc)
                     else
-                        s"""<span class="treenode" data-id="$id" data-path=""><span class="mark">▶</span> ${escapeHtml(
-                              loc
-                            )}</span><div class="subtree" hidden></div>"""
+                        goto +
+                            s"""<span class="treenode" data-id="$id" data-path=""><span class="mark">▶</span> ${escapeHtml(
+                                  loc
+                                )}</span><div class="subtree" hidden></div>"""
                 val pct = oneDecimalPct(e.cpu, totalCpu)
                 val barW = (e.cpu * 120 / maxCpu).toInt
                 sb.append(
@@ -540,8 +552,10 @@ object ProfileFormatter {
                     else
                         s" style='background:rgba(220,40,40,${0.08 + 0.5 * (cpu.toDouble / maxCpu)})'"
                 val gut = if cpu == 0 then "" else s"$cpu cpu / $mem mem / $cnt×"
+                // Anchor profiled lines so the By Source Location tab can jump straight here.
+                val anchor = if e.isDefined then s" id=\"${locAnchor(file, ln)}\"" else ""
                 sb.append(
-                  s"<tr$rowStyle><td class='ln'>$ln</td><td class='cost'>$gut</td><td class='code'>${escapeHtml(text)}</td></tr>\n"
+                  s"<tr$anchor$rowStyle><td class='ln'>$ln</td><td class='cost'>$gut</td><td class='code'>${escapeHtml(text)}</td></tr>\n"
                 )
             }
             sb.append("</table>\n")
@@ -646,6 +660,12 @@ object ProfileFormatter {
         s"${col1.padTo(col1Width, ' ')}  ${count.reverse.padTo(countWidth, ' ').reverse}  ${mem.reverse.padTo(memWidth, ' ').reverse}  ${cpu.reverse.padTo(cpuWidth, ' ').reverse}"
     }
 
+    /** Deterministic HTML anchor id for a `(file, line)` — computed identically in both the By
+      * Source Location table and the Annotated Source view so one can link to the other.
+      */
+    private def locAnchor(file: String, line: Int): String =
+        "loc_" + file.map(c => if c.isLetterOrDigit then c else '_').mkString + "_" + line
+
     /** Shorten file path to just the filename without extension. */
     private def shortFile(path: String): String = {
         val sep = math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
@@ -693,7 +713,10 @@ nav.tabs { position: sticky; top: 0; background: #fafafa; padding: 8px 0; margin
 .treenode { cursor: pointer; }
 .treenode .mark { color: #4a90d9; font-size: 0.8em; }
 .subtree { margin-left: 14px; border-left: 1px solid #ddd; padding-left: 8px; }
-.treeleaf { color: #999; }"""
+.treeleaf { color: #999; }
+a.goto { cursor: pointer; color: #4a90d9; text-decoration: none; margin-right: 2px; }
+a.goto:hover { color: #1c5fa8; }
+table.src tr.hl { background: #fff3cd !important; outline: 2px solid #f0ad4e; }"""
 
     private val htmlScript: String =
         """function scalusFilter(q){q=(q||'').toLowerCase();document.querySelectorAll('table.sortable tbody tr').forEach(function(tr){tr.style.display=tr.textContent.toLowerCase().indexOf(q)>=0?'':'none';});}
@@ -727,6 +750,11 @@ document.addEventListener('click',function(e){
   var t=e.target;
   while(t&&t.nodeType===1){if(t.classList&&t.classList.contains('treenode')){scalusToggle(t);return;}t=t.parentNode;}
 });
+function scalusGoto(anchor){
+  scalusTab('annotated');
+  var el=document.getElementById(anchor);
+  if(el){el.scrollIntoView({block:'center'});el.classList.add('hl');setTimeout(function(){el.classList.remove('hl');},1800);}
+}
 function scalusTab(id){
   document.querySelectorAll('.tab-panel').forEach(function(p){p.hidden=(p.id!==id);});
   document.querySelectorAll('.tab-btn').forEach(function(b){b.classList.toggle('active', b.getAttribute('data-tab')===id);});

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -11,6 +11,22 @@ object ProfileFormatter {
     private def feeLovelace(prices: Option[ExUnitPrices], mem: Long, cpu: Long): Option[Long] =
         prices.map(p => ExUnits(memory = mem, steps = cpu).fee(p).value)
 
+    /** Estimated cost carried by each transition edge A→B: the target node's self-cost distributed
+      * across B's incoming edges by traversal frequency —
+      * `edgeCost(A→B) = selfCost(B) · count(A→B) / Σ_X count(X→B)`. Always finite (no recursion),
+      * and the incoming edges of B sum back (up to integer rounding) to B's self-cost. Returns one
+      * `(edge, mem, cpu)` per transition.
+      */
+    private def edgeCosts(data: ProfilingData): Seq[(SourceTransition, Long, Long)] = {
+        val selfByLoc = data.bySourceLocation.map(e => (e.file, e.line) -> (e.memory, e.cpu)).toMap
+        val inDeg = data.transitions.groupMapReduce(t => (t.toFile, t.toLine))(_.count)(_ + _)
+        data.transitions.map { t =>
+            val (mem, cpu) = selfByLoc.getOrElse((t.toFile, t.toLine), (0L, 0L))
+            val d = inDeg.getOrElse((t.toFile, t.toLine), 0L)
+            if d <= 0 then (t, 0L, 0L) else (t, mem * t.count / d, cpu * t.count / d)
+        }
+    }
+
     /** `lovelace` rendered as ADA with 6 decimals, using integer math so the output is independent
       * of the platform default locale (1 ADA = 1_000_000 lovelace).
       */
@@ -21,9 +37,6 @@ object ProfileFormatter {
 
     /** Max rows rendered per HTML table before collapsing into a "… and N more" note. */
     private val htmlRowCap = 200
-
-    /** Max locations shown on each axis of the transition matrix (keeps it readable). */
-    private val matrixCap = 24
 
     /** Max incoming edges kept per node in the By-Source-Location call tree. */
     private val treeChildCap = 50
@@ -335,8 +348,8 @@ object ProfileFormatter {
     /** Renders profiling data as a self-contained, interactive HTML page.
       *
       * The page bundles its own CSS/JS (no external dependencies): sortable, filterable tables with
-      * %-of-CPU bars, a transition matrix heatmap with a hot-edges table, and — when source text is
-      * supplied — a per-line cost-annotated source view (the flagship view).
+      * %-of-CPU bars, a cost-ranked hot-edges table, and — when source text is supplied — a
+      * per-line cost-annotated source view (the flagship view).
       *
       * @param data
       *   the profiling data
@@ -399,9 +412,7 @@ object ProfileFormatter {
               )
             )
 
-        if data.transitions.nonEmpty then
-            section("matrix", "Transition Matrix")(appendTransitionMatrix(_, data))
-            section("edges", "Hot Edges")(appendHotEdges(_, data))
+        if data.transitions.nonEmpty then section("edges", "Hot Edges")(appendHotEdges(_, data))
 
         val sb = new StringBuilder
         val pageTitle =
@@ -519,14 +530,33 @@ object ProfileFormatter {
                         Seq((t.fromFile, t.fromLine), (t.toFile, t.toLine))
                     )).distinct
             val idOf = allLocs.zipWithIndex.toMap
-            // Incoming edges per destination id (hottest first, capped).
-            val inByDest: Map[Int, Seq[(Int, Long)]] =
+            // Estimated cost on each transition edge (target self-cost × entry-frequency share),
+            // shown as fee when priced else cpu; used on tree branches and the Downstream column.
+            val edgeCostList = edgeCosts(data)
+            val edgeDisplayCost: Map[(String, Int, String, Int), Long] =
+                edgeCostList.map { case (t, mem, cpu) =>
+                    (t.fromFile, t.fromLine, t.toFile, t.toLine) ->
+                        feeLovelace(data.prices, mem, cpu).getOrElse(cpu)
+                }.toMap
+            // Downstream cost a location pushes into its callees = Σ over its outgoing edges.
+            val downstreamByLoc: Map[(String, Int), Long] =
+                edgeCostList
+                    .groupMapReduce(c => (c._1.fromFile, c._1.fromLine))(c =>
+                        feeLovelace(data.prices, c._2, c._3).getOrElse(c._3)
+                    )(_ + _)
+            // Incoming edges per destination id (hottest first, capped): (sourceId, count, edgeCost).
+            val inByDest: Map[Int, Seq[(Int, Long, Long)]] =
                 data.transitions
                     .groupBy(t => idOf((t.toFile, t.toLine)))
                     .view
                     .mapValues(ts =>
-                        ts.map(t => (idOf((t.fromFile, t.fromLine)), t.count))
-                            .sortBy(-_._2)
+                        ts.map(t =>
+                            (
+                              idOf((t.fromFile, t.fromLine)),
+                              t.count,
+                              edgeDisplayCost((t.fromFile, t.fromLine, t.toFile, t.toLine))
+                            )
+                        ).sortBy(-_._2)
                             .take(treeChildCap)
                     )
                     .toMap
@@ -547,16 +577,19 @@ object ProfileFormatter {
             sb.append(
               inByDest
                   .map((destId, ins) =>
-                      s"$destId:[${ins.map((fid, c) => s"[$fid,$c]").mkString(",")}]"
+                      s"$destId:[${ins.map((fid, c, cost) => s"[$fid,$c,$cost]").mkString(",")}]"
                   )
                   .mkString(",")
             )
-            sb.append("};\n</script>\n")
+            sb.append(s"};\nvar SCALUS_FEE=${data.prices.isDefined};\n</script>\n")
 
             val maxCpu = math.max(1L, rows.map(_.cpu).max)
             val feeHeader = if data.prices.isDefined then "<th>Fee (lov)</th>" else ""
+            val unit = if data.prices.isDefined then "lov" else "cpu"
+            val hasEdges = data.transitions.nonEmpty
+            val dsHeader = if hasEdges then s"<th>Downstream ($unit)</th>" else ""
             sb.append(
-              s"<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th>$feeHeader<th>%cpu</th></tr></thead><tbody>\n"
+              s"<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th>$feeHeader$dsHeader<th>%cpu</th></tr></thead><tbody>\n"
             )
             rows.take(htmlRowCap).foreach { e =>
                 val loc = s"${shortFile(e.file)}:${e.line}"
@@ -581,8 +614,11 @@ object ProfileFormatter {
                 val barW = (e.cpu * 120 / maxCpu).toInt
                 val feeCell =
                     feeLovelace(data.prices, e.memory, e.cpu).map(f => s"<td>$f</td>").getOrElse("")
+                val dsCell =
+                    if !hasEdges then ""
+                    else s"<td>${downstreamByLoc.getOrElse((e.file, e.line), 0L)}</td>"
                 sb.append(
-                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>$feeCell" +
+                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>$feeCell$dsCell" +
                       s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td></tr>\n"
                 )
             }
@@ -667,59 +703,25 @@ object ProfileFormatter {
         Some(sb.toString)
     }
 
-    /** Transition matrix heatmap: top-N locations by CPU on each axis; cell = transition count. */
-    private def appendTransitionMatrix(sb: StringBuilder, data: ProfilingData): Unit = {
-        val byLocCpu = data.bySourceLocation.map(e => (e.file, e.line) -> e.cpu).toMap
-        val nodes = data.transitions
-            .flatMap(t => Seq((t.fromFile, t.fromLine), (t.toFile, t.toLine)))
-            .distinct
-            .sortBy(loc => -byLocCpu.getOrElse(loc, 0L))
-            .take(matrixCap)
-        if nodes.isEmpty then return
-        val idx = nodes.zipWithIndex.toMap
-        val cells = scala.collection.mutable.HashMap[(Int, Int), Long]()
-        var maxCount = 1L
-        data.transitions.foreach { t =>
-            for fi <- idx.get((t.fromFile, t.fromLine)); ti <- idx.get((t.toFile, t.toLine)) do
-                val v = cells.getOrElse((fi, ti), 0L) + t.count
-                cells((fi, ti)) = v
-                if v > maxCount then maxCount = v
-        }
-        sb.append(
-          s"<p>Top ${nodes.size} locations by CPU; cell = transition count (row = from, column = to).</p>\n"
-        )
-        sb.append("<table class='matrix'><tr><th>from \\ to</th>")
-        nodes.indices.foreach(i => sb.append(s"<th>${i + 1}</th>"))
-        sb.append("</tr>\n")
-        nodes.zipWithIndex.foreach { case (loc, ri) =>
-            sb.append(
-              s"<tr><th class='rowhdr'>${ri + 1}. ${escapeHtml(shortFile(loc._1))}:${loc._2}</th>"
-            )
-            nodes.indices.foreach { ci =>
-                val v = cells.getOrElse((ri, ci), 0L)
-                val style =
-                    if v == 0 then ""
-                    else
-                        s" style='background:rgba(40,120,220,${0.1 + 0.7 * (v.toDouble / maxCount)})'"
-                sb.append(s"<td$style>${if v == 0 then "" else v.toString}</td>")
-            }
-            sb.append("</tr>\n")
-        }
-        sb.append("</table>\n<ol class='legend'>\n")
-        nodes.foreach(loc => sb.append(s"<li>${escapeHtml(shortFile(loc._1))}:${loc._2}</li>\n"))
-        sb.append("</ol>\n")
-    }
-
-    /** Sortable hot-edges table (from → to, count), the full edge list behind the matrix. */
+    /** Hottest control-flow edges, ranked by estimated cost (see [[edgeCosts]]). The Est. Memory /
+      * Est. CPU / Fee are the target node's self-cost distributed across its incoming edges by
+      * traversal frequency, so an edge's columns answer "how much budget flows across this call".
+      */
     private def appendHotEdges(sb: StringBuilder, data: ProfilingData): Unit = {
+        val feeHeader = if data.prices.isDefined then "<th>Fee (lov)</th>" else ""
         sb.append(
-          "<table class='sortable'><thead><tr><th>From</th><th>To</th><th>Count</th></tr></thead><tbody>\n"
+          s"<table class='sortable'><thead><tr><th>From</th><th>To</th><th>Count</th><th>Est. Memory</th><th>Est. CPU</th>$feeHeader</tr></thead><tbody>\n"
         )
-        data.transitions.take(htmlRowCap).foreach { t =>
-            sb.append(
-              s"<tr><td>${escapeHtml(shortFile(t.fromFile))}:${t.fromLine}</td><td>${escapeHtml(shortFile(t.toFile))}:${t.toLine}</td><td>${t.count}</td></tr>\n"
-            )
-        }
+        edgeCosts(data)
+            .sortBy { case (_, _, cpu) => -cpu }
+            .take(htmlRowCap)
+            .foreach { case (t, mem, cpu) =>
+                val feeCell =
+                    feeLovelace(data.prices, mem, cpu).map(f => s"<td>$f</td>").getOrElse("")
+                sb.append(
+                  s"<tr><td>${escapeHtml(shortFile(t.fromFile))}:${t.fromLine}</td><td>${escapeHtml(shortFile(t.toFile))}:${t.toLine}</td><td>${t.count}</td><td>$mem</td><td>$cpu</td>$feeCell</tr>\n"
+                )
+            }
         sb.append("</tbody></table>\n")
         if data.transitions.size > htmlRowCap then
             sb.append(s"<p>… and ${data.transitions.size - htmlRowCap} more edges</p>\n")
@@ -810,9 +812,6 @@ tbody tr:hover { background: #e8f4fd; }
 .bar { display: inline-block; height: 10px; background: #4a90d9; vertical-align: middle; }
 .summary { font-size: 1.1em; margin: 10px 0; }
 .subtitle { font-size: 1.25em; font-weight: 600; color: #2a5b8c; margin: -6px 0 8px; }
-table.matrix td { min-width: 22px; text-align: center; }
-table.matrix th.rowhdr { text-align: left; font-weight: normal; }
-ol.legend { color: #555; font-size: 0.9em; }
 table.src { border: none; width: 100%; }
 table.src td { border: none; padding: 0 8px; }
 table.src td.ln { color: #999; text-align: right; user-select: none; }
@@ -837,12 +836,14 @@ function scalusBuildChildren(container,id,path){
   var ins=(typeof SCALUS_IN!=='undefined'&&SCALUS_IN[id])||[];
   if(!ins.length){container.innerHTML='<div class="treeleaf">(no incoming)</div>';return;}
   var h='';
+  var feeUnit=(typeof SCALUS_FEE!=='undefined'&&SCALUS_FEE)?' lov':' cpu';
   for(var i=0;i<ins.length;i++){
-    var cid=ins[i][0],cnt=ins[i][1],lbl=(typeof SCALUS_LABEL!=='undefined'&&SCALUS_LABEL[cid])||('#'+cid);
+    var cid=ins[i][0],cnt=ins[i][1],cost=ins[i].length>2?ins[i][2]:0,lbl=(typeof SCALUS_LABEL!=='undefined'&&SCALUS_LABEL[cid])||('#'+cid);
+    var costStr=cost?(' · '+cost+feeUnit):'';
     if(path.indexOf(cid)>=0){
-      h+='<div class="treeleaf">↺ '+lbl+' ×'+cnt+' (loop)</div>';
+      h+='<div class="treeleaf">↺ '+lbl+' ×'+cnt+costStr+' (loop)</div>';
     }else{
-      h+='<div class="treerow"><span class="treenode" data-id="'+cid+'" data-path="'+path.join(',')+'"><span class="mark">▶</span> '+lbl+' ×'+cnt+'</span><div class="subtree" hidden></div></div>';
+      h+='<div class="treerow"><span class="treenode" data-id="'+cid+'" data-path="'+path.join(',')+'"><span class="mark">▶</span> '+lbl+' ×'+cnt+costStr+'</span><div class="subtree" hidden></div></div>';
     }
   }
   container.innerHTML=h;

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -10,6 +10,9 @@ object ProfileFormatter {
     /** Max locations shown on each axis of the transition matrix (keeps it readable). */
     private val matrixCap = 24
 
+    /** Max incoming edges kept per node in the By-Source-Location call tree. */
+    private val treeChildCap = 50
+
     /** Renders profiling data as a formatted text table.
       *
       * @param data
@@ -280,16 +283,7 @@ object ProfileFormatter {
             sections += ((id, title, b.toString))
         }
 
-        section("src", "By Source Location")(
-          appendCostTable(
-            _,
-            Seq("Location"),
-            data.bySourceLocation.map(e =>
-                (Seq(s"${shortFile(e.file)}:${e.line}"), e.count, e.memory, e.cpu)
-            ),
-            totalCpu
-          )
-        )
+        section("src", "By Source Location")(appendSourceLocationTable(_, data, totalCpu))
 
         renderAnnotatedSource(data, sources).foreach(html =>
             sections += (("annotated", "Annotated Source", html))
@@ -403,6 +397,85 @@ object ProfileFormatter {
         val sep = math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
         if sep > 0 then platform.createDirectories(path.substring(0, sep))
         platform.writeFile(path, content.getBytes("UTF-8"))
+    }
+
+    /** The "By Source Location" table. Each location cell is the root of a lazily-expanded tree of
+      * *incoming* transitions: click to reveal where control flowed from to reach this location,
+      * then keep drilling (from-from, …). The graph is embedded as compact JS data (O(edges)) and
+      * each level is built on click, so deep/cyclic graphs don't explode the HTML. A node already
+      * present on the current expansion path is shown as a leaf marked `↺ (loop)` rather than
+      * expanded again, which cuts recursive loops.
+      */
+    private def appendSourceLocationTable(
+        sb: StringBuilder,
+        data: ProfilingData,
+        totalCpu: Long
+    ): Unit = {
+        val rows = data.bySourceLocation
+        if rows.isEmpty then sb.append("<p>(none recorded)</p>\n")
+        else
+            // Stable id for every location appearing in the table or in a transition endpoint.
+            val allLocs =
+                (rows.map(e => (e.file, e.line)) ++
+                    data.transitions.flatMap(t =>
+                        Seq((t.fromFile, t.fromLine), (t.toFile, t.toLine))
+                    )).distinct
+            val idOf = allLocs.zipWithIndex.toMap
+            // Incoming edges per destination id (hottest first, capped).
+            val inByDest: Map[Int, Seq[(Int, Long)]] =
+                data.transitions
+                    .groupBy(t => idOf((t.toFile, t.toLine)))
+                    .view
+                    .mapValues(ts =>
+                        ts.map(t => (idOf((t.fromFile, t.fromLine)), t.count))
+                            .sortBy(-_._2)
+                            .take(treeChildCap)
+                    )
+                    .toMap
+
+            // Embed the graph as JS data (labels + incoming adjacency) for lazy expansion.
+            sb.append("<script>\nvar SCALUS_LABEL={")
+            sb.append(
+              allLocs.zipWithIndex
+                  .map((loc, i) =>
+                      s"""$i:"${jsonEsc(escapeHtml(s"${shortFile(loc._1)}:${loc._2}"))}""""
+                  )
+                  .mkString(",")
+            )
+            sb.append("};\nvar SCALUS_IN={")
+            sb.append(
+              inByDest
+                  .map((destId, ins) =>
+                      s"$destId:[${ins.map((fid, c) => s"[$fid,$c]").mkString(",")}]"
+                  )
+                  .mkString(",")
+            )
+            sb.append("};\n</script>\n")
+
+            val maxCpu = math.max(1L, rows.map(_.cpu).max)
+            sb.append(
+              "<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th><th>%cpu</th></tr></thead><tbody>\n"
+            )
+            rows.take(htmlRowCap).foreach { e =>
+                val loc = s"${shortFile(e.file)}:${e.line}"
+                val id = idOf((e.file, e.line))
+                val hasIncoming = inByDest.get(id).exists(_.nonEmpty)
+                val locCell =
+                    if !hasIncoming then escapeHtml(loc)
+                    else
+                        s"""<span class="treenode" data-id="$id" data-path=""><span class="mark">▶</span> ${escapeHtml(
+                              loc
+                            )}</span><div class="subtree" hidden></div>"""
+                val pct = f"${e.cpu * 100.0 / totalCpu}%.1f"
+                val barW = (e.cpu * 120 / maxCpu).toInt
+                sb.append(
+                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>" +
+                      s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td></tr>\n"
+                )
+            }
+            sb.append("</tbody></table>\n")
+            if rows.size > htmlRowCap then
+                sb.append(s"<p>… and ${rows.size - htmlRowCap} more rows</p>\n")
     }
 
     /** A sortable/filterable cost table: label column(s) + count, mem, cpu and a %-of-CPU bar. */
@@ -603,10 +676,44 @@ nav.tabs { position: sticky; top: 0; background: #fafafa; padding: 8px 0; margin
 .tab-btn { font-family: monospace; font-size: 0.95em; padding: 5px 12px; margin: 0 4px 0 0; border: 1px solid #ccc; background: #eee; color: #333; cursor: pointer; border-radius: 4px 4px 0 0; }
 .tab-btn:hover { background: #e0e8f0; }
 .tab-btn.active { background: #4a90d9; border-color: #4a90d9; color: #fff; }
-.tab-panel[hidden] { display: none; }"""
+.tab-panel[hidden] { display: none; }
+.treenode { cursor: pointer; }
+.treenode .mark { color: #4a90d9; font-size: 0.8em; }
+.subtree { margin-left: 14px; border-left: 1px solid #ddd; padding-left: 8px; }
+.treeleaf { color: #999; }"""
 
     private val htmlScript: String =
         """function scalusFilter(q){q=(q||'').toLowerCase();document.querySelectorAll('table.sortable tbody tr').forEach(function(tr){tr.style.display=tr.textContent.toLowerCase().indexOf(q)>=0?'':'none';});}
+function scalusBuildChildren(container,id,path){
+  var ins=(typeof SCALUS_IN!=='undefined'&&SCALUS_IN[id])||[];
+  if(!ins.length){container.innerHTML='<div class="treeleaf">(no incoming)</div>';return;}
+  var h='';
+  for(var i=0;i<ins.length;i++){
+    var cid=ins[i][0],cnt=ins[i][1],lbl=(typeof SCALUS_LABEL!=='undefined'&&SCALUS_LABEL[cid])||('#'+cid);
+    if(path.indexOf(cid)>=0){
+      h+='<div class="treeleaf">↺ '+lbl+' ×'+cnt+' (loop)</div>';
+    }else{
+      h+='<div class="treerow"><span class="treenode" data-id="'+cid+'" data-path="'+path.join(',')+'"><span class="mark">▶</span> '+lbl+' ×'+cnt+'</span><div class="subtree" hidden></div></div>';
+    }
+  }
+  container.innerHTML=h;
+}
+function scalusToggle(node){
+  var sub=node.nextElementSibling;
+  if(!sub)return;
+  if(node.getAttribute('data-built')!=='1'){
+    var id=+node.getAttribute('data-id');
+    var path=(node.getAttribute('data-path')||'').split(',').filter(Boolean).map(Number);
+    scalusBuildChildren(sub,id,path.concat([id]));
+    node.setAttribute('data-built','1');
+  }
+  sub.hidden=!sub.hidden;
+  var m=node.querySelector('.mark');if(m)m.textContent=sub.hidden?'▶':'▼';
+}
+document.addEventListener('click',function(e){
+  var t=e.target;
+  while(t&&t.nodeType===1){if(t.classList&&t.classList.contains('treenode')){scalusToggle(t);return;}t=t.parentNode;}
+});
 function scalusTab(id){
   document.querySelectorAll('.tab-panel').forEach(function(p){p.hidden=(p.id!==id);});
   document.querySelectorAll('.tab-btn').forEach(function(b){b.classList.toggle('active', b.getAttribute('data-tab')===id);});

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfileFormatter.scala
@@ -27,6 +27,107 @@ object ProfileFormatter {
         }
     }
 
+    /** Inclusive (cumulative) cost per source location over the call graph (`data.transitions` =
+      * caller→callee call edges): a node's self-cost plus the cost of everything it calls, with
+      * each callee's inclusive cost shared back to its callers by call frequency. Returns one
+      * `(mem, cpu)` per location.
+      *
+      * The call graph can still contain cycles (recursion, higher-order calls), on which the naive
+      * recurrence diverges, so strongly-connected components are collapsed with Tarjan's algorithm
+      * and the inclusive cost is accumulated over the resulting DAG (Tarjan emits SCCs in
+      * reverse-topological order, so each component's successors are already done when it is
+      * processed). Every node in a recursive nest shares the nest's total; roots sum to the budget.
+      */
+    private def inclusiveCosts(data: ProfilingData): Map[(String, Int), (Long, Long)] = {
+        val nodes: Array[(String, Int)] =
+            (data.bySourceLocation.map(e => (e.file, e.line)) ++
+                data.transitions.flatMap(t =>
+                    Seq((t.fromFile, t.fromLine), (t.toFile, t.toLine))
+                )).distinct.toArray
+        val n = nodes.length
+        if n == 0 then return Map.empty
+        val nodeIdx = nodes.zipWithIndex.toMap
+        val selfMem = new Array[Long](n)
+        val selfCpu = new Array[Long](n)
+        data.bySourceLocation.foreach { e =>
+            val i = nodeIdx((e.file, e.line)); selfMem(i) = e.memory; selfCpu(i) = e.cpu
+        }
+        val succ = Array.fill(n)(scala.collection.mutable.ArrayBuffer[Int]())
+        data.transitions.foreach { t =>
+            val u = nodeIdx((t.fromFile, t.fromLine)); val v = nodeIdx((t.toFile, t.toLine))
+            if u != v then succ(u) += v
+        }
+        val succA = succ.map(_.distinct.toArray)
+
+        // Iterative Tarjan SCC (explicit stacks so deep graphs don't blow the JVM stack).
+        val index = Array.fill(n)(-1)
+        val low = new Array[Int](n)
+        val onStack = new Array[Boolean](n)
+        val tStack = scala.collection.mutable.ArrayBuffer[Int]()
+        val sccId = Array.fill(n)(-1)
+        val sccOrder = scala.collection.mutable.ArrayBuffer[Int]() // emission order = reverse topo
+        var counter = 0
+        var sccCount = 0
+        val work = scala.collection.mutable.ArrayBuffer[(Int, Int)]() // (node, next succ index)
+        var start = 0
+        while start < n do
+            if index(start) == -1 then
+                work += ((start, 0))
+                while work.nonEmpty do
+                    val (v, pi) = work.last
+                    if pi == 0 then
+                        index(v) = counter; low(v) = counter; counter += 1
+                        tStack += v; onStack(v) = true
+                    if pi < succA(v).length then
+                        work(work.length - 1) = (v, pi + 1)
+                        val w = succA(v)(pi)
+                        if index(w) == -1 then work += ((w, 0))
+                        else if onStack(w) then low(v) = math.min(low(v), index(w))
+                    else
+                        if low(v) == index(v) then
+                            var done = false
+                            while !done do
+                                val w = tStack.remove(tStack.length - 1)
+                                onStack(w) = false; sccId(w) = sccCount
+                                if w == v then done = true
+                            sccOrder += sccCount; sccCount += 1
+                        work.remove(work.length - 1)
+                        if work.nonEmpty then
+                            val parent = work.last._1
+                            low(parent) = math.min(low(parent), low(v))
+            start += 1
+
+        // Condensation: aggregate cross-SCC edge counts, external in-degree, per-SCC self cost.
+        val condCount = scala.collection.mutable.HashMap[(Int, Int), Long]()
+        data.transitions.foreach { t =>
+            val u = sccId(nodeIdx((t.fromFile, t.fromLine)))
+            val v = sccId(nodeIdx((t.toFile, t.toLine)))
+            if u != v then condCount((u, v)) = condCount.getOrElse((u, v), 0L) + t.count
+        }
+        val inDegExt = new Array[Long](sccCount)
+        val outEdges = Array.fill(sccCount)(scala.collection.mutable.ArrayBuffer[(Int, Long)]())
+        condCount.foreach { case ((u, v), c) => inDegExt(v) += c; outEdges(u) += ((v, c)) }
+        val sccMem = new Array[Long](sccCount)
+        val sccCpu = new Array[Long](sccCount)
+        var i = 0
+        while i < n do
+            sccMem(sccId(i)) += selfMem(i); sccCpu(sccId(i)) += selfCpu(i); i += 1
+
+        // Accumulate inclusive cost over the DAG in reverse-topological (emission) order.
+        val incMem = new Array[Long](sccCount)
+        val incCpu = new Array[Long](sccCount)
+        sccOrder.foreach { u =>
+            var m = sccMem(u); var c = sccCpu(u)
+            outEdges(u).foreach { case (v, cnt) =>
+                val d = inDegExt(v)
+                if d > 0 then { m += incMem(v) * cnt / d; c += incCpu(v) * cnt / d }
+            }
+            incMem(u) = m; incCpu(u) = c
+        }
+
+        nodes.indices.map(j => nodes(j) -> (incMem(sccId(j)), incCpu(sccId(j)))).toMap
+    }
+
     /** `lovelace` rendered as ADA with 6 decimals, using integer math so the output is independent
       * of the platform default locale (1 ADA = 1_000_000 lovelace).
       */
@@ -376,8 +477,10 @@ object ProfileFormatter {
             sections += ((id, title, b.toString))
         }
 
+        val incl = inclusiveCosts(data)
+
         section("src", "By Source Location")(
-          appendSourceLocationTable(_, data, totalCpu, sources.keySet)
+          appendSourceLocationTable(_, data, totalCpu, sources.keySet, incl)
         )
 
         renderAnnotatedSource(data, sources).foreach(html =>
@@ -518,7 +621,8 @@ object ProfileFormatter {
         sb: StringBuilder,
         data: ProfilingData,
         totalCpu: Long,
-        annotatedFiles: Set[String]
+        annotatedFiles: Set[String],
+        inclusive: Map[(String, Int), (Long, Long)]
     ): Unit = {
         val rows = data.bySourceLocation
         if rows.isEmpty then sb.append("<p>(none recorded)</p>\n")
@@ -587,9 +691,10 @@ object ProfileFormatter {
             val feeHeader = if data.prices.isDefined then "<th>Fee (lov)</th>" else ""
             val unit = if data.prices.isDefined then "lov" else "cpu"
             val hasEdges = data.transitions.nonEmpty
+            val inclHeader = if hasEdges then s"<th>Inclusive ($unit)</th>" else ""
             val dsHeader = if hasEdges then s"<th>Downstream ($unit)</th>" else ""
             sb.append(
-              s"<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th>$feeHeader$dsHeader<th>%cpu</th></tr></thead><tbody>\n"
+              s"<table class=\"sortable\"><thead><tr><th>Location</th><th>Count</th><th>Memory</th><th>CPU</th>$feeHeader$inclHeader$dsHeader<th>%cpu</th></tr></thead><tbody>\n"
             )
             rows.take(htmlRowCap).foreach { e =>
                 val loc = s"${shortFile(e.file)}:${e.line}"
@@ -614,11 +719,16 @@ object ProfileFormatter {
                 val barW = (e.cpu * 120 / maxCpu).toInt
                 val feeCell =
                     feeLovelace(data.prices, e.memory, e.cpu).map(f => s"<td>$f</td>").getOrElse("")
+                val inclCell =
+                    if !hasEdges then ""
+                    else
+                        val (im, ic) = inclusive.getOrElse((e.file, e.line), (0L, 0L))
+                        s"<td>${feeLovelace(data.prices, im, ic).getOrElse(ic)}</td>"
                 val dsCell =
                     if !hasEdges then ""
                     else s"<td>${downstreamByLoc.getOrElse((e.file, e.line), 0L)}</td>"
                 sb.append(
-                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>$feeCell$dsCell" +
+                  s"<tr><td>$locCell</td><td>${e.count}</td><td>${e.memory}</td><td>${e.cpu}</td>$feeCell$inclCell$dsCell" +
                       s"<td><span class='bar' style='width:${barW}px'></span> $pct%</td></tr>\n"
                 )
             }

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfilingData.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfilingData.scala
@@ -55,6 +55,9 @@ case class SourceTransition(
   *   Optional execution-unit prices. When set, the formatters derive a per-entry on-chain fee (in
   *   lovelace) from each entry's `(mem, cpu)` and render a `fee` column/field alongside count, mem
   *   and cpu. Set it with [[withPrices]] before formatting.
+  * @param entryTrace
+  *   The first distinct source locations executed, in order. Used to root the hot-path tree at the
+  *   first contract location (the literal first step is often a framework/fallback location).
   */
 case class ProfilingData(
     bySourceLocation: Seq[SourceLocationProfile],
@@ -62,7 +65,8 @@ case class ProfilingData(
     byLocationFunction: Seq[LocationFunctionProfile],
     transitions: Seq[SourceTransition],
     totalBudget: ExUnits,
-    prices: Option[ExUnitPrices] = None
+    prices: Option[ExUnitPrices] = None,
+    entryTrace: Seq[(String, Int)] = Nil
 ) {
 
     /** Attach execution-unit prices so the formatters emit a derived per-entry fee (lovelace). */

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfilingData.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/ProfilingData.scala
@@ -1,6 +1,6 @@
 package scalus.uplc.eval
 
-import scalus.cardano.ledger.ExUnits
+import scalus.cardano.ledger.{ExUnitPrices, ExUnits}
 
 /** Profile entry for a single source location. */
 case class SourceLocationProfile(
@@ -51,11 +51,20 @@ case class SourceTransition(
   *   sorted by count descending
   * @param totalBudget
   *   Total budget spent during profiled execution
+  * @param prices
+  *   Optional execution-unit prices. When set, the formatters derive a per-entry on-chain fee (in
+  *   lovelace) from each entry's `(mem, cpu)` and render a `fee` column/field alongside count, mem
+  *   and cpu. Set it with [[withPrices]] before formatting.
   */
 case class ProfilingData(
     bySourceLocation: Seq[SourceLocationProfile],
     byFunction: Seq[FunctionProfile],
     byLocationFunction: Seq[LocationFunctionProfile],
     transitions: Seq[SourceTransition],
-    totalBudget: ExUnits
-)
+    totalBudget: ExUnits,
+    prices: Option[ExUnitPrices] = None
+) {
+
+    /** Attach execution-unit prices so the formatters emit a derived per-entry fee (lovelace). */
+    def withPrices(prices: ExUnitPrices): ProfilingData = copy(prices = Some(prices))
+}

--- a/scalus-core/shared/src/main/scala/scalus/uplc/eval/RestrictingBudgetSpenderWithScriptDump.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/eval/RestrictingBudgetSpenderWithScriptDump.scala
@@ -6,15 +6,21 @@ import scalus.uplc.eval.*
 
 class RestrictingBudgetSpenderWithScriptDump(
     maxBudget: ExUnits,
-    debugDumpFilesForTesting: Boolean
+    debugDumpFilesForTesting: Boolean,
+    logPath: String
 ) extends RestrictingBudgetSpender(maxBudget) {
+
+    /** Back-compat constructor: appends to the historical `scalus.log` in the working directory. */
+    def this(maxBudget: ExUnits, debugDumpFilesForTesting: Boolean) =
+        this(maxBudget, debugDumpFilesForTesting, "scalus.log")
+
     override def spendBudget(cat: ExBudgetCategory, budget: ExUnits, env: CekValEnv): Unit = {
         if debugDumpFilesForTesting then
             cat match
                 case ExBudgetCategory.BuiltinApp(fun) =>
                     val logMessage =
                         s"fun $$${fun}, cost: ExUnits { mem: ${budget.memory}, cpu: ${budget.steps} }\n"
-                    platform.appendFile("scalus.log", logMessage.getBytes("UTF-8"))
+                    platform.appendFile(logPath, logMessage.getBytes("UTF-8"))
                 case _ =>
         super.spendBudget(cat, budget, env)
     }

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/CekProfilerTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/CekProfilerTest.scala
@@ -80,7 +80,7 @@ class CekProfilerTest extends AnyFunSuite {
         val profile = result.profile.get
         val text = ProfileFormatter.toText(profile)
         assert(text.contains("Profile by Source Location"))
-        assert(text.contains("Profile by Function"))
+        assert(text.contains("Profile by Builtin"))
         assert(text.contains("Total:"))
     }
 
@@ -91,7 +91,7 @@ class CekProfilerTest extends AnyFunSuite {
         val html = ProfileFormatter.toHtml(profile)
         assert(html.contains("<!DOCTYPE html>"))
         assert(html.contains("By Source Location"))
-        assert(html.contains("By Function"))
+        assert(html.contains("By Builtin"))
         assert(html.contains("</html>"))
     }
 

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -1,7 +1,7 @@
 package scalus.uplc.eval
 
 import org.scalatest.funsuite.AnyFunSuite
-import scalus.cardano.ledger.ExUnits
+import scalus.cardano.ledger.{ExUnitPrices, ExUnits, NonNegativeInterval}
 
 class ProfileFormatterTest extends AnyFunSuite {
 
@@ -62,6 +62,32 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(json.contains("\"fromLine\":3"))
     }
 
+    test("a derived fee column/field appears across formats when prices are attached") {
+        // mainnet-like prices: 0.0577 / mem unit, 0.0000721 / cpu step.
+        // fee = ceil(0.0577*mem + 0.0000721*cpu): Foo:3 (100,200) -> 6, total (150,260) -> 9.
+        val priced = data.withPrices(
+          ExUnitPrices(NonNegativeInterval(577, 10000), NonNegativeInterval(721, 10000000))
+        )
+
+        // JSON: per-entry and total fee in lovelace (the shape LLMs consume); absent without prices
+        val json = ProfileFormatter.toJson(priced)
+        assert(json.contains("\"cpu\":200,\"fee\":6"))
+        assert(json.contains("\"fee\":9")) // total
+        assert(!ProfileFormatter.toJson(data).contains("\"fee\""))
+
+        // CSV: trailing fee column only when priced
+        val csv = ProfileFormatter.toCsv(priced)
+        assert(csv.startsWith("section,key,detail,count,mem,cpu,fee\n"))
+        assert(csv.contains("total,,,0,150,260,9"))
+        assert(ProfileFormatter.toCsv(data).startsWith("section,key,detail,count,mem,cpu\n"))
+
+        // HTML: a Fee column and a total fee; neither present without prices
+        val html = ProfileFormatter.toHtml(priced)
+        assert(html.contains("<th>Fee (lov)</th>"))
+        assert(html.contains("fee=9 lovelace"))
+        assert(!ProfileFormatter.toHtml(data).contains("Fee (lov)"))
+    }
+
     test("toHtml is self-contained and includes all views") {
         val html = ProfileFormatter.toHtml(data)
         assert(html.startsWith("<!DOCTYPE html>"))
@@ -78,6 +104,18 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("class=\"tab-btn"))
         assert(html.contains("class=\"tab-panel\""))
         assert(html.contains("scalusTab"))
+    }
+
+    test("toHtml shows the profiled contract/test-case title in the head and on top") {
+        // default: generic head title, no subtitle
+        val plain = ProfileFormatter.toHtml(data)
+        assert(plain.contains("<title>Scalus Profile</title>"))
+        assert(!plain.contains("class=\"subtitle\""))
+
+        // with a label: it appears in the <head> title and as a subtitle on top, HTML-escaped
+        val titled = ProfileFormatter.toHtml(data, sources, title = "Foo<Validator> & spend")
+        assert(titled.contains("<title>Scalus Profile — Foo&lt;Validator&gt; &amp; spend</title>"))
+        assert(titled.contains("<p class=\"subtitle\">Foo&lt;Validator&gt; &amp; spend</p>"))
     }
 
     test("By Source Location rows expand into a recursive incoming-call tree") {

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -21,6 +21,22 @@ class ProfileFormatterTest extends AnyFunSuite {
       totalBudget = ExUnits(memory = 150, steps = 260)
     )
 
+    // A simple acyclic call chain A→B→C with known self-costs, for inclusive-cost / Hot Path checks.
+    private val chain = ProfilingData(
+      bySourceLocation = Seq(
+        SourceLocationProfile("Chain.scala", 1, memory = 1, cpu = 10, count = 1),
+        SourceLocationProfile("Chain.scala", 2, memory = 2, cpu = 20, count = 1),
+        SourceLocationProfile("Chain.scala", 3, memory = 4, cpu = 100, count = 1)
+      ),
+      byFunction = Nil,
+      byLocationFunction = Nil,
+      transitions = Seq(
+        SourceTransition("Chain.scala", 1, "Chain.scala", 2, count = 1),
+        SourceTransition("Chain.scala", 2, "Chain.scala", 3, count = 1)
+      ),
+      totalBudget = ExUnits(memory = 7, steps = 130)
+    )
+
     private val sources = Map(
       "Foo.scala" -> IndexedSeq(
         "object Foo {",
@@ -143,6 +159,23 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("<td>Foo:3</td><td>Foo:4</td><td>4</td><td>50</td><td>60</td>"))
         // By Source Location gains a Downstream column (cost a line pushes into its callees)
         assert(html.contains("<th>Downstream (cpu)</th>"))
+    }
+
+    test("inclusive cost accumulates over the call DAG (Inclusive column)") {
+        val html = ProfileFormatter.toHtml(chain)
+        // inclusive(C)=100 (self); inclusive(B)=20+100=120; inclusive(A)=10+120=130 (=total budget).
+        // The Inclusive column carries these even though the self CPU column is 100, 20, 10.
+        assert(html.contains("<th>Inclusive (cpu)</th>"))
+        assert(html.contains("<td>130</td>")) // A: inclusive = whole chain
+        assert(html.contains("<td>120</td>")) // B: self 20 + C's 100
+    }
+
+    test("inclusive cost does not diverge on cycles (SCC collapse)") {
+        // `data` has the Foo:3 ⇄ Foo:4 2-cycle: it collapses to one SCC whose inclusive cpu is the
+        // total budget (260) — every member shares it, no blow-up.
+        val html = ProfileFormatter.toHtml(data)
+        assert(html.contains("<th>Inclusive (cpu)</th>"))
+        assert(html.contains("<td>260</td>"))
     }
 
     test("toHtml with sources renders the annotated-source view") {

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -33,7 +33,7 @@ class ProfileFormatterTest extends AnyFunSuite {
     test("toText still renders the legacy sections") {
         val text = ProfileFormatter.toText(data)
         assert(text.contains("Profile by Source Location"))
-        assert(text.contains("Profile by Function"))
+        assert(text.contains("Profile by Builtin"))
         assert(text.contains("Total:"))
     }
 
@@ -48,7 +48,7 @@ class ProfileFormatterTest extends AnyFunSuite {
         val csv = ProfileFormatter.toCsv(data)
         assert(csv.startsWith("section,key,detail,count,mem,cpu\n"))
         assert(csv.contains("location,Foo.scala:3,,5,100,200"))
-        assert(csv.contains("function,AddInteger"))
+        assert(csv.contains("builtin,AddInteger"))
         assert(csv.contains("edge,Foo.scala:3,Foo.scala:4,4"))
         assert(csv.contains("total,,,0,150,260"))
     }
@@ -66,13 +66,18 @@ class ProfileFormatterTest extends AnyFunSuite {
         val html = ProfileFormatter.toHtml(data)
         assert(html.startsWith("<!DOCTYPE html>"))
         assert(html.contains("By Source Location"))
-        assert(html.contains("By Function"))
+        assert(html.contains("By Builtin"))
         assert(html.contains("Transition Matrix"))
         assert(html.contains("Hot Edges"))
         // bundled, no external dependency
         assert(html.contains("<script>"))
         assert(html.contains("scalusFilter"))
         assert(html.contains("</html>"))
+        // sections are navigable tabs, not one long scroll
+        assert(html.contains("nav class=\"tabs\""))
+        assert(html.contains("class=\"tab-btn"))
+        assert(html.contains("class=\"tab-panel\""))
+        assert(html.contains("scalusTab"))
     }
 
     test("toHtml with sources renders the annotated-source view") {

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -105,11 +105,14 @@ class ProfileFormatterTest extends AnyFunSuite {
 
     test("By Source Location links to the Annotated Source line (cross-tab nav)") {
         val html = ProfileFormatter.toHtml(data, sources)
-        // a jump button in the location table and the matching anchor on the source line
         assert(html.contains("class=\"goto\""))
-        assert(html.contains("scalusGoto('loc_Foo_scala_3')"))
-        assert(html.contains("id=\"loc_Foo_scala_3\""))
         assert(html.contains("function scalusGoto"))
+        // every goto button must target an anchor id that actually exists on a source line
+        val anchors = "scalusGoto\\('([^']+)'\\)".r.findAllMatchIn(html).map(_.group(1)).toList
+        assert(anchors.nonEmpty, "expected at least one goto button")
+        anchors.foreach(a =>
+            assert(html.contains(s"""id="$a""""), s"no source line anchored as $a")
+        )
     }
 
     test("no goto button when the source is not annotated") {

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -103,6 +103,21 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("200 cpu / 100 mem"))
     }
 
+    test("By Source Location links to the Annotated Source line (cross-tab nav)") {
+        val html = ProfileFormatter.toHtml(data, sources)
+        // a jump button in the location table and the matching anchor on the source line
+        assert(html.contains("class=\"goto\""))
+        assert(html.contains("scalusGoto('loc_Foo_scala_3')"))
+        assert(html.contains("id=\"loc_Foo_scala_3\""))
+        assert(html.contains("function scalusGoto"))
+    }
+
+    test("no goto button when the source is not annotated") {
+        // without sources there is no Annotated Source tab to navigate to
+        val html = ProfileFormatter.toHtml(data)
+        assert(!html.contains("class=\"goto\""))
+    }
+
     test("html escaping is applied to rendered content") {
         val tricky = data.copy(
           byFunction = Seq(FunctionProfile("a<b>&c", memory = 1, cpu = 1, count = 1))

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -80,6 +80,21 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("scalusTab"))
     }
 
+    test("By Source Location rows expand into a recursive incoming-call tree") {
+        val html = ProfileFormatter.toHtml(data)
+        // Locations are tree roots; the incoming graph is embedded as JS data for lazy expansion.
+        assert(html.contains("class=\"treenode\""))
+        assert(html.contains("var SCALUS_IN="))
+        assert(html.contains("var SCALUS_LABEL="))
+        assert(html.contains("scalusToggle"))
+        // both endpoints are labelled, and the Foo:3 -> Foo:4 edge (count 4) is in the adjacency
+        assert(html.contains("\"Foo:4\""))
+        assert(html.contains("\"Foo:3\""))
+        assert(html.contains(",4]"))
+        // the loop-cutoff path is threaded through data-path
+        assert(html.contains("data-path="))
+    }
+
     test("toHtml with sources renders the annotated-source view") {
         val html = ProfileFormatter.toHtml(data, sources)
         assert(html.contains("Annotated Source"))

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -93,7 +93,6 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.startsWith("<!DOCTYPE html>"))
         assert(html.contains("By Source Location"))
         assert(html.contains("By Builtin"))
-        assert(html.contains("Transition Matrix"))
         assert(html.contains("Hot Edges"))
         // bundled, no external dependency
         assert(html.contains("<script>"))
@@ -125,12 +124,25 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("var SCALUS_IN="))
         assert(html.contains("var SCALUS_LABEL="))
         assert(html.contains("scalusToggle"))
-        // both endpoints are labelled, and the Foo:3 -> Foo:4 edge (count 4) is in the adjacency
+        // both endpoints are labelled, and the Foo:3 -> Foo:4 edge (count 4, est. cpu 60) is in
+        // the adjacency as [sourceId, count, edgeCost]
         assert(html.contains("\"Foo:4\""))
         assert(html.contains("\"Foo:3\""))
-        assert(html.contains(",4]"))
+        assert(html.contains(",4,60]"))
         // the loop-cutoff path is threaded through data-path
         assert(html.contains("data-path="))
+    }
+
+    test("transition edges carry an estimated cost that conserves node self-cost") {
+        val html = ProfileFormatter.toHtml(data)
+        // edgeCost(A→B) = selfCost(B) · count(A→B)/inDeg(B). Here every share is 1, so each edge
+        // carries its target's full self-cost — Hot Edges shows From|To|Count|Mem|CPU:
+        //   Foo:4→Foo:3 carries Foo:3 (mem 100, cpu 200), count 1
+        //   Foo:3→Foo:4 carries Foo:4 (mem 50, cpu 60), count 4
+        assert(html.contains("<td>Foo:4</td><td>Foo:3</td><td>1</td><td>100</td><td>200</td>"))
+        assert(html.contains("<td>Foo:3</td><td>Foo:4</td><td>4</td><td>50</td><td>60</td>"))
+        // By Source Location gains a Downstream column (cost a line pushes into its callees)
+        assert(html.contains("<th>Downstream (cpu)</th>"))
     }
 
     test("toHtml with sources renders the annotated-source view") {

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -1,0 +1,93 @@
+package scalus.uplc.eval
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.ledger.ExUnits
+
+class ProfileFormatterTest extends AnyFunSuite {
+
+    private val data = ProfilingData(
+      bySourceLocation = Seq(
+        SourceLocationProfile("Foo.scala", 3, memory = 100, cpu = 200, count = 5),
+        SourceLocationProfile("Foo.scala", 4, memory = 50, cpu = 60, count = 2)
+      ),
+      byFunction = Seq(FunctionProfile("AddInteger", memory = 30, cpu = 40, count = 3)),
+      byLocationFunction = Seq(
+        LocationFunctionProfile("Foo.scala", 3, "AddInteger", memory = 30, cpu = 40, count = 3)
+      ),
+      transitions = Seq(
+        SourceTransition("Foo.scala", 3, "Foo.scala", 4, count = 4),
+        SourceTransition("Foo.scala", 4, "Foo.scala", 3, count = 1)
+      ),
+      totalBudget = ExUnits(memory = 150, steps = 260)
+    )
+
+    private val sources = Map(
+      "Foo.scala" -> IndexedSeq(
+        "object Foo {",
+        "  def add(a: BigInt, b: BigInt) =",
+        "    a + b",
+        "  val x = add(1, 2)"
+      )
+    )
+
+    test("toText still renders the legacy sections") {
+        val text = ProfileFormatter.toText(data)
+        assert(text.contains("Profile by Source Location"))
+        assert(text.contains("Profile by Function"))
+        assert(text.contains("Total:"))
+    }
+
+    test("summary is compact and lists top entries") {
+        val s = ProfileFormatter.summary(data)
+        assert(s.contains("Total: mem=150 cpu=260"))
+        assert(s.contains("AddInteger"))
+        assert(s.contains("Foo:3") || s.contains("Foo.scala:3") || s.contains("Foo:"))
+    }
+
+    test("toCsv has a header and rows for every section") {
+        val csv = ProfileFormatter.toCsv(data)
+        assert(csv.startsWith("section,key,detail,count,mem,cpu\n"))
+        assert(csv.contains("location,Foo.scala:3,,5,100,200"))
+        assert(csv.contains("function,AddInteger"))
+        assert(csv.contains("edge,Foo.scala:3,Foo.scala:4,4"))
+        assert(csv.contains("total,,,0,150,260"))
+    }
+
+    test("toJson includes all sections") {
+        val json = ProfileFormatter.toJson(data)
+        assert(json.contains("\"totalBudget\""))
+        assert(json.contains("\"bySourceLocation\""))
+        assert(json.contains("\"byFunction\""))
+        assert(json.contains("\"transitions\""))
+        assert(json.contains("\"fromLine\":3"))
+    }
+
+    test("toHtml is self-contained and includes all views") {
+        val html = ProfileFormatter.toHtml(data)
+        assert(html.startsWith("<!DOCTYPE html>"))
+        assert(html.contains("By Source Location"))
+        assert(html.contains("By Function"))
+        assert(html.contains("Transition Matrix"))
+        assert(html.contains("Hot Edges"))
+        // bundled, no external dependency
+        assert(html.contains("<script>"))
+        assert(html.contains("scalusFilter"))
+        assert(html.contains("</html>"))
+    }
+
+    test("toHtml with sources renders the annotated-source view") {
+        val html = ProfileFormatter.toHtml(data, sources)
+        assert(html.contains("Annotated Source"))
+        assert(html.contains("def add(a: BigInt, b: BigInt)"))
+        // a profiled line carries its cost in the gutter
+        assert(html.contains("200 cpu / 100 mem"))
+    }
+
+    test("html escaping is applied to rendered content") {
+        val tricky = data.copy(
+          byFunction = Seq(FunctionProfile("a<b>&c", memory = 1, cpu = 1, count = 1))
+        )
+        val html = ProfileFormatter.toHtml(tricky)
+        assert(html.contains("a&lt;b&gt;&amp;c"))
+    }
+}

--- a/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/eval/ProfileFormatterTest.scala
@@ -37,6 +37,45 @@ class ProfileFormatterTest extends AnyFunSuite {
       totalBudget = ExUnits(memory = 7, steps = 130)
     )
 
+    // Entry E(1) calls B(2, cheap) and C(3, expensive); C calls D(4). Exercises the Hot Paths tree:
+    // it must root at E and branch (E→C→D and E→B).
+    private val branch = ProfilingData(
+      bySourceLocation = Seq(
+        SourceLocationProfile("T.scala", 1, memory = 1, cpu = 10, count = 1),
+        SourceLocationProfile("T.scala", 2, memory = 1, cpu = 30, count = 1),
+        SourceLocationProfile("T.scala", 3, memory = 1, cpu = 50, count = 1),
+        SourceLocationProfile("T.scala", 4, memory = 1, cpu = 70, count = 1)
+      ),
+      byFunction = Nil,
+      byLocationFunction = Nil,
+      transitions = Seq(
+        SourceTransition("T.scala", 1, "T.scala", 2, count = 1),
+        SourceTransition("T.scala", 1, "T.scala", 3, count = 1),
+        SourceTransition("T.scala", 3, "T.scala", 4, count = 1)
+      ),
+      totalBudget = ExUnits(memory = 4, steps = 160),
+      entryTrace = Seq(("T.scala", 1))
+    )
+
+    // Like `branch` but the entry trace starts in a framework file that calls the contract entry.
+    private val fwBranch = ProfilingData(
+      bySourceLocation = Seq(
+        SourceLocationProfile("Framework.scala", 9, memory = 1, cpu = 5, count = 1),
+        SourceLocationProfile("T.scala", 1, memory = 1, cpu = 10, count = 1),
+        SourceLocationProfile("T.scala", 2, memory = 1, cpu = 30, count = 1),
+        SourceLocationProfile("T.scala", 3, memory = 1, cpu = 50, count = 1)
+      ),
+      byFunction = Nil,
+      byLocationFunction = Nil,
+      transitions = Seq(
+        SourceTransition("Framework.scala", 9, "T.scala", 1, count = 1),
+        SourceTransition("T.scala", 1, "T.scala", 2, count = 1),
+        SourceTransition("T.scala", 1, "T.scala", 3, count = 1)
+      ),
+      totalBudget = ExUnits(memory = 4, steps = 95),
+      entryTrace = Seq(("Framework.scala", 9), ("T.scala", 1))
+    )
+
     private val sources = Map(
       "Foo.scala" -> IndexedSeq(
         "object Foo {",
@@ -168,6 +207,30 @@ class ProfileFormatterTest extends AnyFunSuite {
         assert(html.contains("<th>Inclusive (cpu)</th>"))
         assert(html.contains("<td>130</td>")) // A: inclusive = whole chain
         assert(html.contains("<td>120</td>")) // B: self 20 + C's 100
+    }
+
+    test("Hot Paths tree roots at the entry and branches by edge cost") {
+        val html = ProfileFormatter.toHtml(branch)
+        assert(html.contains("Hot Paths"))
+        assert(html.contains("class='hottree'"))
+        // entry T:1 is the root; edges carry the callee's self cost: E→C 50, E→B 30, C→D 70
+        assert(html.contains(">T:1</span> <span class='c'>(entry"))
+        assert(html.contains(">T:3</span> <span class='c'>· 50 cpu")) // E→C (heavier branch first)
+        assert(html.contains(">T:2</span> <span class='c'>· 30 cpu")) // E→B (the other branch)
+        assert(html.contains(">T:4</span> <span class='c'>· 70 cpu")) // C→D, nested under C
+        // no entry recorded → no Hot Paths tab
+        assert(!ProfileFormatter.toHtml(chain).contains("Hot Paths"))
+    }
+
+    test("Hot Paths roots at the first contract-file location, not the framework entry") {
+        // With contract sources known, the tree roots at the contract entry (T:1), skipping the
+        // framework step that ran first.
+        val rooted = ProfileFormatter.toHtml(fwBranch, Map("T.scala" -> IndexedSeq("a", "b", "c")))
+        assert(rooted.contains(">T:1</span> <span class='c'>(entry"))
+        // Without contract info, the root is the literal first step — the framework location.
+        assert(
+          ProfileFormatter.toHtml(fwBranch).contains(">Framework:9</span> <span class='c'>(entry")
+        )
     }
 
     test("inclusive cost does not diverge on cycles (SCC collapse)") {

--- a/scalus-examples/jvm/src/test/scala/scalus/benchmarks/KnightsTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/benchmarks/KnightsTest.scala
@@ -57,7 +57,11 @@ class KnightsTest extends AnyFunSuite, ScalusTest:
         private def evalWithOptionalProfile(using PlutusVM): Result =
             if profilingEnabled then
                 val result = term.evaluateProfile
-                result.profile.foreach(p => info(ProfileFormatter.toText(p, maxRows = 200)))
+                result.profile.foreach { p =>
+                    info(ProfileFormatter.summary(p))
+                    ProfileFormatter.writeHtml(p, "target/knights-profile.html")
+                    info("Wrote profile to target/knights-profile.html")
+                }
                 result
             else term.evaluateDebug
 

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
@@ -12,7 +12,7 @@ import scalus.cardano.onchain.plutus.v1.PosixTime
 import scalus.testing.kit.ScalusTest
 import scalus.testing.kit.TestUtil.{genesisHash, getScriptContextV3}
 import scalus.testing.kit.Party.{Alice, Bob, Charles}
-import scalus.uplc.eval.Result
+import scalus.uplc.eval.{ProfileFormatter, Result}
 import scalus.utils.await
 
 class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
@@ -96,6 +96,10 @@ object AuctionValidatorTest extends ScalusTest {
     import scalus.cardano.onchain.plutus.v3.{TxId, TxOutRef}
     import scalus.cardano.node.BlockchainProvider
     import scalus.cardano.address.Network
+
+    // Set to true to emit an interactive HTML profile (target/auction-profile.html) when a
+    // validator runs. Off by default so the suite stays fast and side-effect free.
+    private val profilingEnabled = false
 
     // Party to role mapping
     private val sellerParty = Alice
@@ -583,6 +587,21 @@ object AuctionValidatorTest extends ScalusTest {
 
         val result = program.runWithDebug(scriptContext)
         assert(result.isSuccess, s"Validator failed: $result, logs: ${result.logs.mkString(", ")}")
+
+        // Set `profilingEnabled = true` to emit an interactive profile of this validator. The
+        // `include` filter keeps only the example's own sources (skipping inlined framework code).
+        if profilingEnabled then
+            program.runWithProfile(scriptContext).profile.foreach { p =>
+                println(ProfileFormatter.summary(p))
+                ProfileFormatter.writeHtml(
+                  p,
+                  "target/auction-profile.html",
+                  include =
+                      f => !f.contains("/scalus-core/") && !f.contains("/scalus-cardano-ledger/")
+                )
+                println("Wrote profile to target/auction-profile.html")
+            }
+
         result
 
     private def createProvider(): Emulator =

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
@@ -97,9 +97,12 @@ object AuctionValidatorTest extends ScalusTest {
     import scalus.cardano.node.BlockchainProvider
     import scalus.cardano.address.Network
 
-    // Set to true to emit an interactive HTML profile (target/auction-profile.html) when a
-    // validator runs. Off by default so the suite stays fast and side-effect free.
-    private val profilingEnabled = false
+    // Emit an interactive HTML profile (target/auction-profile.html) when a validator runs.
+    // Off by default so the suite stays fast and side-effect free; enable with env
+    // `SCALUS_PROFILE=1` (env so it reaches the forked test JVM) or `-Dscalus.profile=true`.
+    private val profilingEnabled =
+        sys.env.get("SCALUS_PROFILE").contains("1") ||
+            sys.props.get("scalus.profile").contains("true")
 
     // Party to role mapping
     private val sellerParty = Alice
@@ -412,7 +415,14 @@ object AuctionValidatorTest extends ScalusTest {
                 )
                 .await()
 
-            runValidatorWithUtxos(provider, auction, tx, auctionUtxo.input, utxosBeforeBid).budget
+            runValidatorWithUtxos(
+              provider,
+              auction,
+              tx,
+              auctionUtxo.input,
+              utxosBeforeBid,
+              "First bid"
+            ).budget
 
         private def runOutbidWithBudget(
             provider: Emulator,
@@ -464,7 +474,8 @@ object AuctionValidatorTest extends ScalusTest {
               auction,
               tx,
               auctionUtxo.input,
-              allUtxosBeforeOutbid
+              allUtxosBeforeOutbid,
+              "Outbid with refund"
             ).budget
 
         private def runEndWithWinnerWithBudget(
@@ -516,7 +527,8 @@ object AuctionValidatorTest extends ScalusTest {
               auction,
               tx,
               auctionUtxo.input,
-              allUtxosBeforeEnd
+              allUtxosBeforeEnd,
+              "End auction with winner"
             ).budget
 
         private def runEndNoBidsWithBudget(
@@ -554,7 +566,14 @@ object AuctionValidatorTest extends ScalusTest {
                 )
                 .await()
 
-            runValidatorWithUtxos(provider, auction, tx, auctionUtxo.input, utxosBeforeEnd).budget
+            runValidatorWithUtxos(
+              provider,
+              auction,
+              tx,
+              auctionUtxo.input,
+              utxosBeforeEnd,
+              "End auction without bids"
+            ).budget
 
     /** Run validator with pre-captured UTxOs (for when the transaction has already been submitted)
       */
@@ -563,7 +582,8 @@ object AuctionValidatorTest extends ScalusTest {
         auction: AuctionInstance,
         tx: Transaction,
         scriptInput: TransactionInput,
-        knownUtxos: Map[TransactionInput, TransactionOutput]
+        knownUtxos: Map[TransactionInput, TransactionOutput],
+        label: String = ""
     ): Result =
         given CardanoInfo = provider.cardanoInfo
         // Merge known utxos with any remaining utxos from provider
@@ -591,13 +611,17 @@ object AuctionValidatorTest extends ScalusTest {
         // Set `profilingEnabled = true` to emit an interactive profile of this validator. The
         // `include` filter keeps only the example's own sources (skipping inlined framework code).
         if profilingEnabled then
-            program.runWithProfile(scriptContext).profile.foreach { p =>
+            program.runWithProfile(scriptContext).profile.foreach { rawProfile =>
+                // Attach prices so the report derives a per-entry on-chain fee (lovelace).
+                val p =
+                    rawProfile.withPrices(provider.cardanoInfo.protocolParams.executionUnitPrices)
                 println(ProfileFormatter.summary(p))
                 ProfileFormatter.writeHtml(
                   p,
                   "target/auction-profile.html",
                   include =
-                      f => !f.contains("/scalus-core/") && !f.contains("/scalus-cardano-ledger/")
+                      f => !f.contains("/scalus-core/") && !f.contains("/scalus-cardano-ledger/"),
+                  title = if label.isEmpty then "AuctionValidator" else s"AuctionValidator — $label"
                 )
                 println("Wrote profile to target/auction-profile.html")
             }

--- a/scalus-testkit/shared/src/main/scala/scalus/testing/kit/ScalusTest.scala
+++ b/scalus-testkit/shared/src/main/scala/scalus/testing/kit/ScalusTest.scala
@@ -72,6 +72,10 @@ trait ScalusTest extends ArbitraryInstances, Assertions {
             val appliedScript = self $ scriptContext.toData
             appliedScript.evaluateDebug
 
+        /** Like [[runWithDebug]] but also collects profiling data (`result.profile`). */
+        def runWithProfile(scriptContext: ScriptContext)(using vm: PlutusVM): Result =
+            vm.evaluateScriptProfile((self $ scriptContext.toData).deBruijnedProgram)
+
     protected def random[A: Arbitrary]: A = {
         Arbitrary.arbitrary[A].sample.get
     }


### PR DESCRIPTION
Closes #93.

Evaluator debug dumps were keyed on the **volatile txid**, so fee-balancing
re-evaluations of the same logical transaction produced duplicate `.flat` files
("some appear twice"), and the per-builtin cost log was appended without ever
being truncated ("number way too high"). There was also no manifest mapping a
dumped file back to its script, and no docs.

## Changes

**Bug fix (closes #93 items 1 & 2)**
- Dumps now use **stable, overwriting** filenames `<scriptHash>-<language>-<tag>-<index>.flat`
  (txid removed from the name), so re-evaluation overwrites instead of accumulating.
- `budget.log` is **truncated once per evaluation** (replaces the unbounded-append `scalus.log`).
- A **`manifest.json`** is written: txid + per-script `{file, scriptHash, language, tag, index, spentBudget}`.
- Duplicate redeemer entries are de-duplicated for the dump/manifest.

**`EvaluatorReportConfig`** (new, in `scalus-core`)
- Typed replacement for the `debugDumpFilesForTesting: Boolean` flag: output directory + artifact
  selection (+ profile fields reserved for a follow-up).
- Overridable without recompiling via `SCALUS_DUMP`, `SCALUS_DUMP_DIR`, `SCALUS_PROFILE*` env vars
  (`SCALUS_DUMP=off` is a kill-switch). Env layers field-by-field on top of the in-code config.
- New cross-platform `platform.createDirectories` (JVM + Node.js; no-op default elsewhere).

## Compatibility
- **MiMa-clean** (`sbt mima` green): no existing signatures changed. The legacy
  `debugDumpFilesForTesting` constructors are retained and map through `fromLegacyBoolean`; a new
  `report: EvaluatorReportConfig` `apply` overload is added; the spender keeps its 2-arg constructor
  via an auxiliary one.
- The on-disk dump **layout** changes intentionally (debug-only artifacts, not a stable API); the
  conformance test's cleanup glob is updated and the change is noted in the CHANGELOG.

## Tests
- `EvaluatorReportConfigTest` — legacy-boolean mapping + env precedence/kill-switch.
- `EvalPlutusScriptsTest` — end-to-end: two evaluations of the same tx produce exactly 2 stable
  `.flat` files (no duplication) + a `manifest.json` with the expected fields.
- Verified: JVM + JS compile, full targeted test run, `sbt mima`.

## Follow-up (deferred)
Wiring `ProfilingBudgetSpender` into the evaluator + the per-line-annotated clickable HTML profile
report + docs page (steps 3–4 of the design).