### PR TITLE
Cross-build Scalus on Scala 3.8.x (3.8.4 JVM/JS, 3.8.3 Native) alongside 3.3.7 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -484,6 +484,7 @@ lazy val scalusTestkit = crossProject(JSPlatform, JVMPlatform)
     .settings(
       name := "scalus-testkit",
       scalaVersion := scalaVersion.value,
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,
       scalacOptions += "-Xmax-inlines:100", // needed for Arbitrary[Certificate] = autoDerived
 
@@ -574,6 +575,7 @@ lazy val scalusExamples = crossProject(JSPlatform, JVMPlatform)
     .disablePlugins(MimaPlugin) // disable Migration Manager for Scala
     .enablePlugins(ScalusBlueprintPlugin)
     .settings(
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       PluginDependency,
       scalacOptions ++= commonScalacOptions,
       publish / skip := true,
@@ -636,6 +638,7 @@ lazy val scalusDesignPatterns = project
     .dependsOn(scalus.jvm, scalusTestkit.jvm)
     .disablePlugins(MimaPlugin) // disable Migration Manager for Scala
     .settings(
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       PluginDependency,
       scalacOptions ++= commonScalacOptions,
       publish / skip := true,
@@ -651,6 +654,7 @@ lazy val `scalus-bloxbean-cardano-client-lib` = project
     .in(file("bloxbean-cardano-client-lib"))
     .dependsOn(scalus.jvm, scalusCardanoLedger.jvm)
     .settings(
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       publish / skip := false,
       scalacOptions ++= commonScalacOptions,
       mimaPreviousArtifacts := Set(organization.value %% name.value % scalusCompatibleVersion),
@@ -750,6 +754,7 @@ lazy val scalusCardanoLedger = crossProject(JSPlatform, JVMPlatform)
     .disablePlugins(MimaPlugin) // disable Migration Manager for Scala
     .settings(
       name := "scalus-cardano-ledger",
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,
       scalacOptions += "-Xmax-inlines:100", // needed for upickle derivation of CostModel
       libraryDependencies ++= Seq(
@@ -850,6 +855,7 @@ lazy val scalusEthereumKzgCeremony = project
     .dependsOn(scalus.jvm)
     .disablePlugins(MimaPlugin)
     .settings(
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       name := "scalus-ethereum-kzg-ceremony",
       scalacOptions ++= commonScalacOptions,
       libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.38.14",

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,11 @@ val monocleVersion = "3.3.0"
 //ThisBuild / scalaVersion := "3.8.0-RC1-bin-SNAPSHOT"
 //ThisBuild / scalaVersion := "3.3.7-RC1-bin-SNAPSHOT"
 //ThisBuild / scalaVersion := "3.7.3-RC1-bin-SNAPSHOT"
-ThisBuild / scalaVersion := "3.3.7"
+// LTS is the default build version; the next series is used to cross-build the
+// compiler plugin (which depends on the unstable scala3-compiler internal API).
+val scala3LtsVersion = "3.3.7"
+val scala3NextVersion = "3.8.4"
+ThisBuild / scalaVersion := scala3LtsVersion
 ThisBuild / organization := "org.scalus"
 ThisBuild / organizationName := "Scalus"
 ThisBuild / organizationHomepage := Some(url("https://scalus.org/"))
@@ -225,6 +229,7 @@ lazy val scalusPlugin = project
     .settings(
       name := "scalus-plugin",
       crossVersion := CrossVersion.full,
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,
 //      scalacOptions += "-Wunused:all",
       // Manually set a fixed version to avoid recompilation on every commit
@@ -289,6 +294,15 @@ lazy val scalusPlugin = project
 //          sharedFiles.map(file => baseDir / file)
 //      },
       Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "shared" / "scala",
+      // Version-specific sources: the StandardPlugin phase-registration hook differs between the
+      // 3.3.x LTS (`init`) and 3.5+/3.8.x (`initialize(using Context)`). See PluginCompat.
+      Compile / unmanagedSourceDirectories += {
+          val srcDir = (Compile / sourceDirectory).value
+          CrossVersion.partialVersion(scalaVersion.value) match {
+              case Some((3, minor)) if minor >= 5 => srcDir / "scala-3.8"
+              case _                              => srcDir / "scala-3.3"
+          }
+      },
       cleanFiles += (Compile / sourceDirectory).value / "shared",
       // Ensure shared files are copied before any source inspection
       Compile / sourceGenerators += Def.task {

--- a/build.sbt
+++ b/build.sbt
@@ -597,6 +597,9 @@ lazy val scalusExamples = crossProject(JSPlatform, JVMPlatform)
     )
     .jvmSettings(
       Test / fork := true,
+      // Expose the compiler version to tests so they can pick version-specific baselines
+      // (budgets / script sizes drift between the 3.3.x LTS and 3.8.x). See ScalaCompilerVersion.
+      Test / javaOptions += s"-Dscalus.test.scalaVersion=${scalaVersion.value}",
       libraryDependencies += "com.bloxbean.cardano" % "cardano-client-backend-blockfrost" % cardanoClientLibVersion
     )
     .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,9 @@ val monocleVersion = "3.3.0"
 // compiler plugin (which depends on the unstable scala3-compiler internal API).
 val scala3LtsVersion = "3.3.7"
 val scala3NextVersion = "3.8.4"
+// Scala Native 0.5.12 (latest) supports Scala up to 3.8.3, not 3.8.4 — so the Native platform
+// targets 3.8.3 while JVM/JS use 3.8.4. Same desugaring as 3.8.4, so budgets/baselines match.
+val scala3NativeNextVersion = "3.8.3"
 ThisBuild / scalaVersion := scala3LtsVersion
 ThisBuild / organization := "org.scalus"
 ThisBuild / organizationName := "Scalus"
@@ -229,7 +232,9 @@ lazy val scalusPlugin = project
     .settings(
       name := "scalus-plugin",
       crossVersion := CrossVersion.full,
-      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
+      // Build the plugin for 3.8.3 too: the Native platform compiles on 3.8.3 and a Scala 3
+      // compiler plugin must match the compiler version.
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NativeNextVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,
 //      scalacOptions += "-Wunused:all",
       // Manually set a fixed version to avoid recompilation on every commit
@@ -424,6 +429,9 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     )
     .jsConfigure { project => project.enablePlugins(ScalaJSBundlerPlugin) }
     .nativeSettings(
+      // Native targets 3.8.3 (highest Scala that Scala Native 0.5.12 supports), not the 3.8.4
+      // used by JVM/JS. Run with `++3.8.3 scalusNative/test`.
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NativeNextVersion),
       // Disable doc due to scaladoc NPE bug on Native platform
       Compile / doc / sources := Seq.empty,
       Test / doc / sources := Seq.empty,

--- a/build.sbt
+++ b/build.sbt
@@ -318,6 +318,7 @@ lazy val scalus = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .settings(
       name := "scalus",
       scalaVersion := scalaVersion.value,
+      crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,
       scalacOptions += "-Xmax-inlines:100", // needed for upickle derivation of CostModel
       // scalacOptions += "-P:scalus:debugLevel=1",

--- a/scalus-core/shared/src/main/scala/scalus/uplc/transform/EtaReduce.scala
+++ b/scalus-core/shared/src/main/scala/scalus/uplc/transform/EtaReduce.scala
@@ -2,8 +2,8 @@ package scalus.uplc.transform
 
 import scalus.*
 import scalus.uplc.Term.*
-import scalus.uplc.transform.TermAnalysis.isPure
-import scalus.uplc.{NamedDeBruijn, Term}
+import scalus.uplc.transform.TermAnalysis.{freeVars, isPure}
+import scalus.uplc.Term
 import scalus.uplc.eval.{Log, Logger}
 
 /** Performs eta-reduction on a term.
@@ -42,7 +42,7 @@ class EtaReduce(logger: Logger = new Log()) extends Optimizer:
     /** Performs eta-reduction on a term. */
     private def etaReduce(term: Term): Term = term match
         case LamAbs(name1, Term.Apply(f, Term.Var(name2, _), _), ann)
-            if name1 == name2.name && !freeNames(f).contains(name1) && f.isPure =>
+            if name1 == name2.name && !f.freeVars.contains(name1) && f.isPure =>
             logger.log(s"Eta-reducing term: ${f.show}")
             etaReduce(f)
         case LamAbs(name, body, ann) =>
@@ -52,15 +52,6 @@ class EtaReduce(logger: Logger = new Log()) extends Optimizer:
         case Force(term, ann)   => Force(etaReduce(term), ann)
         case Delay(term, ann)   => Delay(etaReduce(term), ann)
         case _                  => term
-
-    /** Returns the set of free names in a term */
-    private def freeNames(term: Term): Set[String] = term match
-        case Var(NamedDeBruijn(name, _), _) => Set(name)
-        case LamAbs(name, body, _)          => freeNames(body) - name
-        case Apply(f, arg, _)               => freeNames(f) ++ freeNames(arg)
-        case Force(term, _)                 => freeNames(term)
-        case Delay(term, _)                 => freeNames(term)
-        case _                              => Set.empty
 
 object EtaReduce:
     def apply(term: Term): Term = new EtaReduce().apply(term)

--- a/scalus-examples/jvm/src/test/scala/scalus/ScalaCompilerVersion.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/ScalaCompilerVersion.scala
@@ -1,0 +1,32 @@
+package scalus
+
+/** Selects test baselines that legitimately differ between Scala compiler versions.
+  *
+  * Budgets and compiled-script sizes shift between Scala 3.3.x (LTS) and 3.8.x because the host
+  * compiler desugars some constructs more leanly since 3.8.x — e.g. a tuple-datum pattern match no
+  * longer destructures-then-reconstructs the tuple, so the Scalus plugin sees a smaller tree. These
+  * differences are correctness-neutral (the contracts evaluate identically); only the exact
+  * budget/size numbers change. The 3.3.x LTS keeps the older, larger baselines; 3.8.x and the next
+  * LTS (which inherits the leaner desugaring) use the smaller ones.
+  *
+  * The active compiler version is injected by build.sbt (`-Dscalus.test.scalaVersion`). It can't be
+  * read from `scala.util.Properties.versionNumberString`, which reports the 2.13 standard-library
+  * version (`2.13.x`) on the Scala 3.3 LTS rather than the compiler version.
+  */
+object ScalaCompilerVersion {
+
+    /** The compiler version building the tests, e.g. `"3.3.7"` or `"3.8.4"`. */
+    val version: String = sys.props.getOrElse("scalus.test.scalaVersion", "3.3.7")
+
+    private val (major, minor) = {
+        val parts = version.split("[.\\-]").iterator.flatMap(_.toIntOption)
+        (parts.nextOption().getOrElse(3), parts.nextOption().getOrElse(3))
+    }
+
+    /** True for compilers with the leaner desugaring: Scala 3.8.x and later (incl. the next LTS).
+      */
+    val hasLeanDesugaring: Boolean = major > 3 || (major == 3 && minor >= 8)
+
+    /** The baseline for the active compiler: `pre38` on the 3.3.x LTS, `since38` on 3.8.x+. */
+    def baseline[T](pre38: T, since38: T): T = if hasLeanDesugaring then since38 else pre38
+}

--- a/scalus-examples/jvm/src/test/scala/scalus/benchmarks/ClausifyTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/benchmarks/ClausifyTest.scala
@@ -46,7 +46,10 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 36678249L, steps = 10291484697L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 36678249L, steps = 10291484697L),
+                  since38 = ExUnits(memory = 36172329L, steps = 10110689833L)
+                )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 75014277L, steps = 22595514040L)
             else if options.targetLoweringBackend == TargetLoweringBackend.SumOfProductsLowering
@@ -79,7 +82,10 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 45839773L, steps = 12816668469L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 45839773L, steps = 12816668469L),
+                  since38 = ExUnits(memory = 45311533L, steps = 12627897361L)
+                )
             else
                 options.targetLoweringBackend match {
                     case TargetLoweringBackend.SirToUplcV3Lowering =>
@@ -115,7 +121,10 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 122110206L, steps = 34036176961L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 122110206L, steps = 34036176961L),
+                  since38 = ExUnits(memory = 120921666L, steps = 33611441968L)
+                )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 248968345L, steps = 74900219564L)
             else ExUnits(memory = 152347441L, steps = 26254484239L)
@@ -1087,7 +1096,10 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 165335647L, steps = 45465644813L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 165335647L, steps = 45465644813L),
+                  since38 = ExUnits(memory = 164147107L, steps = 45040909820L)
+                )
             else ExUnits(memory = 344589971L, steps = 100725854354L)
         // val scalusBudget = ExUnits(memory = 214968623L, steps = 37733187149L)
         assert(result.isSuccess)
@@ -1114,7 +1126,10 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 586427375L, steps = 162900902677L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 586427375L, steps = 162900902677L),
+                  since38 = ExUnits(memory = 581725295L, steps = 161220573941L)
+                )
             else ExUnits(memory = 1205574641L, steps = 363306861308L)
         // val scalusBudget = ExUnits(memory = 736503639L, steps = 127163562591L)
         assert(result.isSuccess)

--- a/scalus-examples/jvm/src/test/scala/scalus/benchmarks/knightsdata/KnightsDataTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/benchmarks/knightsdata/KnightsDataTest.scala
@@ -53,7 +53,10 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 117911129L, steps = 36524261717L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 117911129L, steps = 36524261717L),
+                  since38 = ExUnits(memory = 103601789L, steps = 31615968659L)
+                )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 324_452274L, steps = 92346_941030L)
             else if options.targetLoweringBackend == TargetLoweringBackend.SumOfProductsLowering
@@ -153,7 +156,10 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 240825859L, steps = 90235741368L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 240825859L, steps = 90235741368L),
+                  since38 = ExUnits(memory = 227762119L, steps = 85754338250L)
+                )
             else
                 options.targetLoweringBackend match
                     case TargetLoweringBackend.SirToUplcV3Lowering =>
@@ -255,7 +261,10 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val options = summon[Options]
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
-                ExUnits(memory = 401118282L, steps = 161591340661L)
+                ScalaCompilerVersion.baseline(
+                  pre38 = ExUnits(memory = 401118282L, steps = 161591340661L),
+                  since38 = ExUnits(memory = 386786382L, steps = 156675400046L)
+                )
             else
                 options.targetLoweringBackend match {
                     case TargetLoweringBackend.SirToUplcV3Lowering =>

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/PreimageExampleTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/PreimageExampleTest.scala
@@ -96,7 +96,7 @@ class PreimageExampleTest extends BaseValidatorTest {
         // println(validator.showHighlighted)
         val flatSize = validator.flatEncoded.length
         // V3 backend with lambda barriers, optimizeUplc = true
-        assert(flatSize == 249)
+        assert(flatSize == ScalaCompilerVersion.baseline(pre38 = 249, since38 = 231))
         // V3 backend, optimizeUplc = false
         // assert(flatSize == 380)
         // SimpleBackend

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
@@ -1,6 +1,7 @@
 package scalus.examples.auction
 
 import org.scalatest.funsuite.AnyFunSuite
+import scalus.ScalaCompilerVersion
 import scalus.uplc.builtin.ByteString.*
 import scalus.cardano.address.ShelleyAddress
 import scalus.cardano.ledger.*
@@ -64,7 +65,12 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
           action = TestAction.Bid(bidAmount = 3_000_000L),
           expected = Expected.Success
         ).runWithBudget()
-        assert(budget == ExUnits(memory = 189048L, steps = 62219312L))
+        assert(
+          budget == ScalaCompilerVersion.baseline(
+            pre38 = ExUnits(memory = 189048L, steps = 62219312L),
+            since38 = ExUnits(memory = 185992L, steps = 61141450L)
+          )
+        )
     }
 
     test("budget: outbid with refund") {
@@ -72,7 +78,12 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
           action = TestAction.Outbid(newBidAmount = 5_000_000L),
           expected = Expected.Success
         ).runWithBudget()
-        assert(budget == ExUnits(memory = 243306L, steps = 78916057L))
+        assert(
+          budget == ScalaCompilerVersion.baseline(
+            pre38 = ExUnits(memory = 243306L, steps = 78916057L),
+            since38 = ExUnits(memory = 240250L, steps = 77838195L)
+          )
+        )
     }
 
     test("budget: end auction with winner") {
@@ -80,7 +91,12 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
           action = TestAction.EndWithWinner,
           expected = Expected.Success
         ).runWithBudget()
-        assert(budget == ExUnits(memory = 300158L, steps = 93669049L))
+        assert(
+          budget == ScalaCompilerVersion.baseline(
+            pre38 = ExUnits(memory = 300158L, steps = 93669049L),
+            since38 = ExUnits(memory = 293134L, steps = 91522940L)
+          )
+        )
     }
 
     test("budget: end auction without bids") {
@@ -88,7 +104,12 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
           action = TestAction.EndNoBids,
           expected = Expected.Success
         ).runWithBudget()
-        assert(budget == ExUnits(memory = 247525L, steps = 76453575L))
+        assert(
+          budget == ScalaCompilerVersion.baseline(
+            pre38 = ExUnits(memory = 247525L, steps = 76453575L),
+            since38 = ExUnits(memory = 244469L, steps = 75375713L)
+          )
+        )
     }
 }
 

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/paymentsplitter/NaivePaymentSplitterValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/paymentsplitter/NaivePaymentSplitterValidatorTest.scala
@@ -25,21 +25,63 @@ class NaivePaymentSplitterValidatorTest
     private val txId = random[TxId]
     private val scriptHash = contract.script.scriptHash
 
-    private val expectedBudgets: Map[String, ExUnits] = Map(
-      "success when payments are correctly split for a single payee" ->
-          (ExUnits(memory = 259185L, steps = 85439687L)),
-      "success when payments are correctly split between 2 payees" ->
-          (ExUnits(memory = 411335L, steps = 137152186L)),
-      "success when payments are correctly split between 3 payees" ->
-          (ExUnits(memory = 589827L, steps = 200064632L)),
-      "success when split equally and remainder compensates fee - o1" ->
-          (ExUnits(memory = 589827L, steps = 200064632L)),
-      "success when split equally and remainder compensates fee - o2" ->
-          (ExUnits(memory = 589827L, steps = 200064632L)),
-      "success when split equally and remainder compensates fee - o3" ->
-          (ExUnits(memory = 589827L, steps = 200064632L)),
-      "success between 5 payees" -> (ExUnits(memory = 1036037L, steps = 363599593L)),
-      "success with multiple contract UTxOs" -> (ExUnits(memory = 720975L, steps = 248941118L))
+    private val expectedBudgets: Map[String, ExUnits] = ScalaCompilerVersion.baseline(
+      pre38 = Map(
+        "success when payments are correctly split for a single payee" -> ExUnits(
+          memory = 259185L,
+          steps = 85439687L
+        ),
+        "success when payments are correctly split between 2 payees" -> ExUnits(
+          memory = 411335L,
+          steps = 137152186L
+        ),
+        "success when payments are correctly split between 3 payees" -> ExUnits(
+          memory = 589827L,
+          steps = 200064632L
+        ),
+        "success when split equally and remainder compensates fee - o1" -> ExUnits(
+          memory = 589827L,
+          steps = 200064632L
+        ),
+        "success when split equally and remainder compensates fee - o2" -> ExUnits(
+          memory = 589827L,
+          steps = 200064632L
+        ),
+        "success when split equally and remainder compensates fee - o3" -> ExUnits(
+          memory = 589827L,
+          steps = 200064632L
+        ),
+        "success between 5 payees" -> ExUnits(memory = 1036037L, steps = 363599593L),
+        "success with multiple contract UTxOs" -> ExUnits(memory = 720975L, steps = 248941118L)
+      ),
+      since38 = Map(
+        "success when payments are correctly split for a single payee" -> ExUnits(
+          memory = 250549L,
+          steps = 82367764L
+        ),
+        "success when payments are correctly split between 2 payees" -> ExUnits(
+          memory = 400839L,
+          steps = 133415576L
+        ),
+        "success when payments are correctly split between 3 payees" -> ExUnits(
+          memory = 577471L,
+          steps = 195663335L
+        ),
+        "success when split equally and remainder compensates fee - o1" -> ExUnits(
+          memory = 577471L,
+          steps = 195663335L
+        ),
+        "success when split equally and remainder compensates fee - o2" -> ExUnits(
+          memory = 577471L,
+          steps = 195663335L
+        ),
+        "success when split equally and remainder compensates fee - o3" -> ExUnits(
+          memory = 577471L,
+          steps = 195663335L
+        ),
+        "success between 5 payees" -> ExUnits(memory = 1019961L, steps = 357868922L),
+        "success with multiple contract UTxOs" -> ExUnits(memory = 708619L, steps = 244539821L)
+      )
     )
 
     // Run all shared test cases

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/paymentsplitter/OptimizedPaymentSplitterValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/paymentsplitter/OptimizedPaymentSplitterValidatorTest.scala
@@ -24,33 +24,63 @@ class OptimizedPaymentSplitterValidatorTest
     private val txId = random[TxId]
     private val scriptHash = contract.script.scriptHash
 
-    private val expectedRewardBudgets: Map[String, ExUnits] = Map(
-      "success when payments are correctly split for a single payee" -> ExUnits(
-        memory = 210249L,
-        steps = 68110088L
+    private val expectedRewardBudgets: Map[String, ExUnits] = ScalaCompilerVersion.baseline(
+      pre38 = Map(
+        "success when payments are correctly split for a single payee" -> ExUnits(
+          memory = 210249L,
+          steps = 68110088L
+        ),
+        "success when payments are correctly split between 2 payees" -> ExUnits(
+          memory = 286891L,
+          steps = 94499667L
+        ),
+        "success when payments are correctly split between 3 payees" -> ExUnits(
+          memory = 367631L,
+          steps = 123128598L
+        ),
+        "success when split equally and remainder compensates fee - o1" -> ExUnits(
+          memory = 367631L,
+          steps = 123128598L
+        ),
+        "success when split equally and remainder compensates fee - o2" -> ExUnits(
+          memory = 367631L,
+          steps = 123128598L
+        ),
+        "success when split equally and remainder compensates fee - o3" -> ExUnits(
+          memory = 367631L,
+          steps = 123128598L
+        ),
+        "success between 5 payees" -> ExUnits(memory = 541405L, steps = 187104516L),
+        "success with multiple contract UTxOs" -> ExUnits(memory = 491355L, steps = 168323432L)
       ),
-      "success when payments are correctly split between 2 payees" -> ExUnits(
-        memory = 286891L,
-        steps = 94499667L
-      ),
-      "success when payments are correctly split between 3 payees" -> ExUnits(
-        memory = 367631L,
-        steps = 123128598L
-      ),
-      "success when split equally and remainder compensates fee - o1" -> ExUnits(
-        memory = 367631L,
-        steps = 123128598L
-      ),
-      "success when split equally and remainder compensates fee - o2" -> ExUnits(
-        memory = 367631L,
-        steps = 123128598L
-      ),
-      "success when split equally and remainder compensates fee - o3" -> ExUnits(
-        memory = 367631L,
-        steps = 123128598L
-      ),
-      "success between 5 payees" -> ExUnits(memory = 541405L, steps = 187104516L),
-      "success with multiple contract UTxOs" -> ExUnits(memory = 491355L, steps = 168323432L)
+      since38 = Map(
+        "success when payments are correctly split for a single payee" -> ExUnits(
+          memory = 205333L,
+          steps = 66367539L
+        ),
+        "success when payments are correctly split between 2 payees" -> ExUnits(
+          memory = 281975L,
+          steps = 92757118L
+        ),
+        "success when payments are correctly split between 3 payees" -> ExUnits(
+          memory = 362715L,
+          steps = 121386049L
+        ),
+        "success when split equally and remainder compensates fee - o1" -> ExUnits(
+          memory = 362715L,
+          steps = 121386049L
+        ),
+        "success when split equally and remainder compensates fee - o2" -> ExUnits(
+          memory = 362715L,
+          steps = 121386049L
+        ),
+        "success when split equally and remainder compensates fee - o3" -> ExUnits(
+          memory = 362715L,
+          steps = 121386049L
+        ),
+        "success between 5 payees" -> ExUnits(memory = 536489L, steps = 185361967L),
+        "success with multiple contract UTxOs" -> ExUnits(memory = 486439L, steps = 166580883L)
+      )
     )
 
     private val expectedSpendBudget: ExUnits = ExUnits(memory = 61624, steps = 19397022)
@@ -65,7 +95,12 @@ class OptimizedPaymentSplitterValidatorTest
     test("Optimized: budget comparison with multiple UTxOs") {
         val tc = testCases.find(_.name.contains("multiple contract UTxOs")).get
         val (rewardBudget, spendBudget) = runTestCaseWithBudget(tc)
-        assert(rewardBudget == ExUnits(memory = 491355L, steps = 168323432L))
+        assert(
+          rewardBudget == ScalaCompilerVersion.baseline(
+            pre38 = ExUnits(memory = 491355L, steps = 168323432L),
+            since38 = ExUnits(memory = 486439L, steps = 166580883L)
+          )
+        )
         assert(spendBudget == ExUnits(memory = 61624, steps = 19397022))
     }
 

--- a/scalus-plugin/src/main/scala-3.3/scalus/compiler/plugin/PluginCompat.scala
+++ b/scalus-plugin/src/main/scala-3.3/scalus/compiler/plugin/PluginCompat.scala
@@ -1,0 +1,15 @@
+package scalus.compiler.plugin
+
+import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
+
+/** Phase registration for the Scala 3.3.x LTS series.
+  *
+  * On the LTS, `StandardPlugin.init` is the only registration hook (`initialize` was added in
+  * 3.5.0). The shared [[Plugin]] supplies the phases via [[scalusPhases]].
+  */
+trait PluginCompat extends StandardPlugin {
+
+    protected def scalusPhases(options: List[String]): List[PluginPhase]
+
+    override def init(options: List[String]): List[PluginPhase] = scalusPhases(options)
+}

--- a/scalus-plugin/src/main/scala-3.8/scalus/compiler/plugin/PluginCompat.scala
+++ b/scalus-plugin/src/main/scala-3.8/scalus/compiler/plugin/PluginCompat.scala
@@ -1,0 +1,17 @@
+package scalus.compiler.plugin
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
+
+/** Phase registration for the Scala 3.5+ series (3.8.x).
+  *
+  * `StandardPlugin.init` is deprecated since 3.5.0 in favour of `initialize`, which can access the
+  * compiler `Context`. The shared [[Plugin]] supplies the phases via [[scalusPhases]].
+  */
+trait PluginCompat extends StandardPlugin {
+
+    protected def scalusPhases(options: List[String]): List[PluginPhase]
+
+    override def initialize(options: List[String])(using Context): List[PluginPhase] =
+        scalusPhases(options)
+}

--- a/scalus-plugin/src/main/scala/scalus/compiler/plugin/Plugin.scala
+++ b/scalus-plugin/src/main/scala/scalus/compiler/plugin/Plugin.scala
@@ -17,19 +17,19 @@ import scalus.compiler.sir.SIRPosition
 
 import scala.language.implicitConversions
 
-class Plugin extends StandardPlugin {
+class Plugin extends PluginCompat {
     val name: String = "scalus"
     override val description: String = "Compile Scala to Scalus IR"
 
     // val compiledSirs: mutable.Map[String, SIR] = mmutable.Map.empty
 
-    /** For enabling debug in scalus
+    /** Builds the Scalus plugin phases.
       *
-      * Note: In Scala 3.7+, the `init` method is deprecated in favor of `initialize(options)(using
-      * Context)`. When upgrading to Scala 3.7+, rename this method to `initialize` and add the
-      * `(using Context)` parameter.
+      * The phases are registered by the version-specific [[PluginCompat]] mix-in, which adapts to
+      * the `StandardPlugin` registration hook of the active Scala version: the pre-3.5 `init` on
+      * the LTS (3.3.x) and `initialize(options)(using Context)` on 3.5+ (3.8.x).
       */
-    override def init(options: List[String]): List[PluginPhase] = {
+    protected def scalusPhases(options: List[String]): List[PluginPhase] = {
         val debugLevel = options
             .find(_.startsWith("debugLevel="))
             .map(_.substring("debugLevel=".length))

--- a/scalus-plugin/src/main/scala/scalus/compiler/plugin/SIRCompiler.scala
+++ b/scalus-plugin/src/main/scala/scalus/compiler/plugin/SIRCompiler.scala
@@ -912,7 +912,7 @@ final class SIRCompiler(
         }
         val constrType = typer.constructorResultType(constrSymbol)
         val optBaseClass = constrSymbol.info.baseClasses.find { b =>
-            b.flags.is(Flags.Sealed) && b.children.contains(constrSymbol)
+            b.flags.is(Flags.Sealed) && b.children.contains(constrSymbol) && !typer.isTupleClass(b)
         }
         val baseTypeArgs = optBaseClass
             .flatMap { bs =>

--- a/scalus-plugin/src/main/scala/scalus/compiler/plugin/SIRTyper.scala
+++ b/scalus-plugin/src/main/scala/scalus/compiler/plugin/SIRTyper.scala
@@ -33,6 +33,18 @@ class SIRTyper(using Context) {
     private val uplcRepresentationClass =
         Symbols.requiredClass("scalus.compiler.UplcRepresentation")
 
+    /** `scala.Tuple` — the sealed root of the tuple ADT (`EmptyTuple`, `*:`, `TupleN`). */
+    private val tupleClass = Symbols.requiredClass("scala.Tuple")
+
+    /** True for any member of the tuple family (`Tuple2`, `*:`, `EmptyTuple`, ...).
+      *
+      * The tuple hierarchy is sealed and, since Scala 3.5, lists the concrete `TupleN` classes
+      * among its `children`; its base type is the `*:`-cons encoding ending in `EmptyTuple`, which
+      * has no SIR type. Tuples lower to standalone case classes, so they must be excluded from
+      * sum-type parent detection (see [[retrieveParentSymbol]] and `SIRCompiler.makeConstrDecl`).
+      */
+    def isTupleClass(sym: Symbol): Boolean = sym.derivesFrom(tupleClass)
+
     /** Extract a `TypeVarKind` from `@UplcRepr(TypeVar(kind))` on a symbol. Returns `None` if the
       * annotation is absent or its argument isn't a `TypeVar(...)` shape. Used by
       * [[SIRCompiler.compileDefDef]] to stamp the correct kind on a method's `SIRType.TypeVar`.
@@ -670,6 +682,7 @@ class SIRTyper(using Context) {
             val bcChildren = bc.children
             bcChildren.nonEmpty && !bc.flags.is(Flags.Transparent)
             && bcChildren.exists(_ == typeSymbol)
+            && !isTupleClass(bc) // tuples lower to case classes, not sum types; see isTupleClass
         }
         val optParent = parentSyms match
             case Nil         => None


### PR DESCRIPTION
## Summary

Cross-builds the Scalus compiler plugin and library on the latest Scala 3.8.x alongside the 3.3.7 LTS, so the project compiles and tests on both. The default build stays on 3.3.7.

Per-platform "next" versions (each platform's highest fully-supported version):
- **JVM / JS:** 3.3.7 LTS + **3.8.4**
- **Native:** 3.3.7 LTS + **3.8.3** (Scala Native 0.5.12, the latest stable, supports Scala only up to 3.8.3)

## What's here

- **Plugin cross-build** (`3137809f7`) — the one diverging compiler-API call, `StandardPlugin`'s phase-registration hook, isolated into a version-specific `PluginCompat` trait: `scala-3.3` overrides `init`, `scala-3.8` overrides the non-deprecated `initialize(using Context)`. The remaining ~9.4k lines of dotty-internal API usage compile unchanged.
- **Tuple ADT fix** (`8e1d2936a`) — since Scala 3.5 the sealed `scala.Tuple` lists the `TupleN` classes among its `children`, so the plugin mistook tuples for sum types and walked `*:` into `EmptyTuple` (no SIR type). New `SIRTyper.isTupleClass` excludes the tuple family from parent detection.
- **EtaReduce fix** (`ce5af2bcb`) — a latent free-variable check missed `Case`/`Constr`, so `λx.(f x)` could eta-reduce even when `f` referenced `x` inside a `Case`/`Constr`. Surfaced by 3.8.x's case-on-bool lowering; a real bug on both versions. Now uses the canonical `TermAnalysis.freeVars`.
- **All JVM modules + version baselines** (`6880cc26c`, `6498ab145`) — budgets and compiled-script sizes shift slightly because 3.8.x desugars some constructs (e.g. tuple-datum matches) more leanly; correctness-neutral. Added `ScalaCompilerVersion.baseline(pre38, since38)`, keyed on the build-injected compiler version, for the drifting examples assertions.
- **Native on 3.8.3** (`9f9fc2392`) — plugin cross-built for 3.8.3, the `scalus` Native platform pinned to 3.8.3.

## Test status

| Platform | 3.3.7 LTS | next |
|---|---|---|
| JVM | green | **3.8.4** — core 3217 · ledger 774 · testkit 85 · design-patterns 97 · examples 433 |
| JS | green | **3.8.4** — core 2810 · ledger 292 · examples 3 |
| Native | green (2771) | **3.8.3** — 2771 |

## Running

- `++3.8.4 scalusJVM/test`, `++3.8.4 scalusJS/test` (JS per-module — the `js` aggregate falls back to 3.3.7)
- `++3.8.3 scalusNative/test`

Mixed-version builds are delicate: port a module's whole transitive dep set together, since the plugin jar must match the compiler version.
