### PR TITLE
feat: emulator applied-tx log/index + effect-polymorphic findUtxo

### DIFF
--- a/scalus-cardano-ledger/js/src/main/scala/scalus/cardano/node/Emulator.scala
+++ b/scalus-cardano-ledger/js/src/main/scala/scalus/cardano/node/Emulator.scala
@@ -21,30 +21,42 @@ class Emulator(
     val validators: Iterable[STS.Validator] = Emulator.defaultValidators,
     val mutators: Iterable[STS.Mutator] = Emulator.defaultMutators,
     initialCertState: CertState = CertState.empty,
-    initialDatums: Map[DataHash, Data] = Map.empty
+    initialDatums: Map[DataHash, Data] = Map.empty,
+    initialAppliedTxLog: Vector[AppliedTx] = Vector.empty
 ) extends EmulatorBase {
     // JavaScript is single-threaded, so simple vars are safe
     private var state: State = State(initialUtxos, certState = initialCertState)
     private var context: Context = initialContext
-    private var _datums: Map[DataHash, Data] = initialDatums
-    private var _appliedTxs: Set[TransactionHash] = Set.empty
+    private var _datums: Map[DataHash, Data] =
+        initialAppliedTxLog.foldLeft(initialDatums)((acc, a) =>
+            acc ++ EmulatorBase.extractDatums(a.tx)
+        )
+    private var _appliedTxLog: Vector[AppliedTx] = initialAppliedTxLog
+    private var _appliedTxIndex: Map[TransactionHash, AppliedTx] =
+        EmulatorBase.indexAppliedTxs(initialAppliedTxLog)
+    private var _appliedTxs: Set[TransactionHash] = initialAppliedTxLog.map(_.tx.id).toSet
 
     def utxos: Utxos = state.utxos
     def certState: CertState = state.certState
     def currentContext: Context = context
     def datums: Map[DataHash, Data] = _datums
+    def appliedTxLog: Vector[AppliedTx] = _appliedTxLog
+    def appliedTxIndex: Map[TransactionHash, AppliedTx] = _appliedTxIndex
     def appliedTxs: Set[TransactionHash] = _appliedTxs
 
-    private def recordApplied(tx: Transaction): Unit = {
-        _appliedTxs = _appliedTxs + tx.id
-        _datums = _datums ++ EmulatorBase.extractDatums(tx)
+    private def recordApplied(applied: AppliedTx): Unit = {
+        _appliedTxLog = _appliedTxLog :+ applied
+        _appliedTxIndex = _appliedTxIndex + (applied.txHash -> applied)
+        _appliedTxs = _appliedTxs + applied.txHash
+        _datums = _datums ++ EmulatorBase.extractDatums(applied.tx)
     }
 
     def submitSync(transaction: Transaction): Either[SubmitError, TransactionHash] = {
         processTransaction(context, state, transaction) match {
             case Right(newState) =>
+                val spent = EmulatorBase.resolveSpent(state.utxos, transaction)
                 state = newState
-                recordApplied(transaction)
+                recordApplied(AppliedTx(transaction, context.env.slot, spent))
                 Right(transaction.id)
             case Left(t: TransactionException) =>
                 Left(SubmitError.fromException(t))
@@ -58,8 +70,9 @@ class Emulator(
         val ctxWithDebug = context.copy(debugScripts = debugScripts)
         processTransaction(ctxWithDebug, state, transaction) match {
             case Right(newState) =>
+                val spent = EmulatorBase.resolveSpent(state.utxos, transaction)
                 state = newState
-                recordApplied(transaction)
+                recordApplied(AppliedTx(transaction, context.env.slot, spent))
                 Right(transaction.id)
             case Left(t: TransactionException) =>
                 Left(SubmitError.fromException(t))
@@ -71,13 +84,20 @@ class Emulator(
         context = context.copy(env = context.env.copy(slot = slot))
     }
 
+    def clearAppliedTxs(): Unit = {
+        _appliedTxLog = Vector.empty
+        _appliedTxIndex = Map.empty
+        _appliedTxs = Set.empty
+    }
+
     def snapshot(): Emulator = Emulator(
       initialUtxos = this.utxos,
       initialContext = this.context,
       validators = this.validators,
       mutators = this.mutators,
       initialCertState = this.state.certState,
-      initialDatums = this._datums
+      initialDatums = this._datums,
+      initialAppliedTxLog = this._appliedTxLog
     )
 }
 

--- a/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/node/Emulator.scala
+++ b/scalus-cardano-ledger/jvm/src/main/scala/scalus/cardano/node/Emulator.scala
@@ -24,34 +24,45 @@ class Emulator(
     val validators: Iterable[STS.Validator] = Emulator.defaultValidators,
     val mutators: Iterable[STS.Mutator] = Emulator.defaultMutators,
     initialCertState: CertState = CertState.empty,
-    initialDatums: Map[DataHash, Data] = Map.empty
+    initialDatums: Map[DataHash, Data] = Map.empty,
+    initialAppliedTxLog: Vector[AppliedTx] = Vector.empty
 ) extends EmulatorBase {
     private val stateRef =
         new AtomicReference[State](State(initialUtxos, certState = initialCertState))
     private val contextRef = new AtomicReference[Context](initialContext)
-    private val datumsRef = new AtomicReference[Map[DataHash, Data]](initialDatums)
-    private val appliedTxsRef = new AtomicReference[Set[TransactionHash]](Set.empty)
+    private val datumsRef = new AtomicReference[Map[DataHash, Data]](
+      initialAppliedTxLog.foldLeft(initialDatums)((acc, a) =>
+          acc ++ EmulatorBase.extractDatums(a.tx)
+      )
+    )
+    private val appliedTxLogRef = new AtomicReference[Vector[AppliedTx]](initialAppliedTxLog)
+    private val appliedTxIndexRef =
+        new AtomicReference[Map[TransactionHash, AppliedTx]](
+          EmulatorBase.indexAppliedTxs(initialAppliedTxLog)
+        )
+    private val appliedTxsRef =
+        new AtomicReference[Set[TransactionHash]](initialAppliedTxLog.map(_.tx.id).toSet)
 
     def utxos: Utxos = stateRef.get().utxos
     def certState: CertState = stateRef.get().certState
     protected def currentContext: Context = contextRef.get()
     def datums: Map[DataHash, Data] = datumsRef.get()
+    def appliedTxLog: Vector[AppliedTx] = appliedTxLogRef.get()
+    def appliedTxIndex: Map[TransactionHash, AppliedTx] = appliedTxIndexRef.get()
     def appliedTxs: Set[TransactionHash] = appliedTxsRef.get()
 
-    @tailrec
-    private def recordApplied(tx: Transaction): Unit = {
-        val cur = appliedTxsRef.get()
-        if !appliedTxsRef.compareAndSet(cur, cur + tx.id) then recordApplied(tx)
-        else {
-            val extracted = EmulatorBase.extractDatums(tx)
-            if extracted.nonEmpty then {
-                val curDatums = datumsRef.get()
-                if !datumsRef.compareAndSet(curDatums, curDatums ++ extracted) then {
-                    // retry just the datums merge
-                    var d = datumsRef.get()
-                    while !datumsRef.compareAndSet(d, d ++ extracted) do d = datumsRef.get()
-                }
-            }
+    private def recordApplied(applied: AppliedTx): Unit = {
+        var log = appliedTxLogRef.get()
+        while !appliedTxLogRef.compareAndSet(log, log :+ applied) do log = appliedTxLogRef.get()
+        var idx = appliedTxIndexRef.get()
+        while !appliedTxIndexRef.compareAndSet(idx, idx + (applied.txHash -> applied)) do
+            idx = appliedTxIndexRef.get()
+        var txs = appliedTxsRef.get()
+        while !appliedTxsRef.compareAndSet(txs, txs + applied.txHash) do txs = appliedTxsRef.get()
+        val extracted = EmulatorBase.extractDatums(applied.tx)
+        if extracted.nonEmpty then {
+            var d = datumsRef.get()
+            while !datumsRef.compareAndSet(d, d ++ extracted) do d = datumsRef.get()
         }
     }
 
@@ -65,7 +76,13 @@ class Emulator(
         processTransaction(ctx, currentState, transaction) match {
             case Right(newState) =>
                 if stateRef.compareAndSet(currentState, newState) then
-                    recordApplied(transaction)
+                    recordApplied(
+                      AppliedTx(
+                        transaction,
+                        ctx.env.slot,
+                        EmulatorBase.resolveSpent(currentState.utxos, transaction)
+                      )
+                    )
                     Right(transaction.id)
                 else submitSync(transaction)
             case Left(t: TransactionException) =>
@@ -85,7 +102,13 @@ class Emulator(
         processTransaction(ctxWithDebug, currentState, transaction) match {
             case Right(newState) =>
                 if stateRef.compareAndSet(currentState, newState) then
-                    recordApplied(transaction)
+                    recordApplied(
+                      AppliedTx(
+                        transaction,
+                        ctx.env.slot,
+                        EmulatorBase.resolveSpent(currentState.utxos, transaction)
+                      )
+                    )
                     Right(transaction.id)
                 else submitSync(transaction, debugScripts)
             case Left(t: TransactionException) =>
@@ -101,13 +124,20 @@ class Emulator(
         if !contextRef.compareAndSet(ctx, newContext) then setSlot(slot)
     }
 
+    def clearAppliedTxs(): Unit = {
+        appliedTxLogRef.set(Vector.empty)
+        appliedTxIndexRef.set(Map.empty)
+        appliedTxsRef.set(Set.empty)
+    }
+
     def snapshot(): Emulator = Emulator(
       initialUtxos = this.utxos,
       initialContext = this.contextRef.get(),
       validators = this.validators,
       mutators = this.mutators,
       initialCertState = this.stateRef.get().certState,
-      initialDatums = this.datumsRef.get()
+      initialDatums = this.datumsRef.get(),
+      initialAppliedTxLog = this.appliedTxLogRef.get()
     )
 }
 

--- a/scalus-cardano-ledger/jvm/src/test/scala/scalus/cardano/node/EmulatorTest.scala
+++ b/scalus-cardano-ledger/jvm/src/test/scala/scalus/cardano/node/EmulatorTest.scala
@@ -52,6 +52,81 @@ class EmulatorTest extends AnyFunSuite with ScalaCheckPropertyChecks {
         )
     }
 
+    test("Emulator records an applied-transaction log with slot and spent inputs") {
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val provider =
+            Emulator(
+              initialUtxos = initialUtxos,
+              validators = Set.empty,
+              mutators = Emulator.defaultMutators
+            )
+        provider.setSlot(42L)
+
+        assert(provider.appliedTxLog.isEmpty, "log should start empty")
+
+        val tx = TxBuilder(testEnv)
+            .payTo(Bob.address, Value.ada(10))
+            .complete(provider, Alice.address)
+            .await()
+            .transaction
+
+        val submitResult = provider.submit(tx).await()
+        assert(submitResult.isRight, s"submit should succeed: $submitResult")
+
+        val log = provider.appliedTxLog
+        assert(log.size == 1, s"expected a single applied tx, got ${log.size}")
+        val applied = log.head
+        assert(applied.tx.id == tx.id)
+        assert(applied.slot == 42L, "applied slot should be the emulator slot at submission time")
+        // the transaction consumed Alice's genesis UTxO, which is gone from the live set
+        assert(applied.spent == initialUtxos, "spent should be the resolved consumed inputs")
+        assert(!provider.utxos.contains(Input(genesisHash, 0)), "spent input removed from live set")
+        assert(provider.getTransaction(tx.id).contains(tx), "getTransaction finds the applied tx")
+        assert(provider.getTransaction(genesisHash).isEmpty, "unknown hash resolves to None")
+        // index by hash-id
+        assert(provider.appliedTxIndex.keySet == Set(tx.id))
+        assert(provider.getAppliedTx(tx.id).contains(applied), "getAppliedTx returns the record")
+        assert(provider.hasTx(tx.id) && !provider.hasTx(genesisHash))
+        assert(provider.appliedTxs == Set(tx.id), "appliedTxs derives from the index")
+    }
+
+    test("Emulator.clearAppliedTxs resets the log/index but keeps ledger state") {
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val provider =
+            Emulator(
+              initialUtxos = initialUtxos,
+              validators = Set.empty,
+              mutators = Emulator.defaultMutators
+            )
+        val tx = TxBuilder(testEnv)
+            .payTo(Bob.address, Value.ada(10), (_: Transaction) => Data.unit)
+            .complete(provider, Alice.address)
+            .await()
+            .transaction
+        assert(provider.submit(tx).await().isRight)
+
+        val utxosBefore = provider.utxos
+        val datumsBefore = provider.datums
+        assert(provider.appliedTxLog.nonEmpty, "precondition: a tx was applied")
+        assert(provider.datums.nonEmpty, "precondition: the tx carried an inline datum")
+
+        provider.clearAppliedTxs()
+
+        // bookkeeping cleared
+        assert(provider.appliedTxLog.isEmpty)
+        assert(provider.appliedTxIndex.isEmpty)
+        assert(provider.appliedTxs.isEmpty)
+        assert(!provider.hasTx(tx.id))
+        assert(provider.getTransaction(tx.id).isEmpty)
+        // ledger state untouched
+        assert(provider.utxos == utxosBefore, "utxos must be preserved")
+        assert(provider.datums == datumsBefore, "datum cache must be preserved")
+    }
+
     test("Emulator.withRegisteredStakeCredentials allows zero-withdrawal without registration tx") {
         val alwaysOkScript = PlutusV3.alwaysOk
         val scriptHash = alwaysOkScript.script.scriptHash

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/BlockchainProvider.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/BlockchainProvider.scala
@@ -26,6 +26,40 @@ trait BlockchainReaderTF[F[_]] {
       */
     def findUtxos(query: UtxoQuery): F[Either[UtxoQueryError, Utxos]]
 
+    /** Find a single UTxO by its transaction input.
+      *
+      * @return
+      *   Right(utxo) if found, Left(NotFound) otherwise
+      */
+    def findUtxo(input: TransactionInput): F[Either[UtxoQueryError, Utxo]] =
+        mapF(findUtxos(UtxoQuery(UtxoSource.FromInputs(Set(input))))) { result =>
+            result.flatMap { utxos =>
+                utxos.headOption match
+                    case Some((i, o)) => Right(Utxo(i, o))
+                    case None => Left(UtxoQueryError.NotFound(UtxoSource.FromInputs(Set(input))))
+            }
+        }
+
+    /** Find UTxOs by a set of transaction inputs (fails with NotFound if not all are found). */
+    def findUtxos(inputs: Set[TransactionInput]): F[Either[UtxoQueryError, Utxos]] =
+        mapF(findUtxos(UtxoQuery(UtxoSource.FromInputs(inputs)))) { result =>
+            result.flatMap { foundUtxos =>
+                if foundUtxos.size == inputs.size then Right(foundUtxos)
+                else Left(UtxoQueryError.NotFound(UtxoSource.FromInputs(inputs)))
+            }
+        }
+
+    /** Find all UTxOs at the given address. */
+    def findUtxos(address: Address): F[Either[UtxoQueryError, Utxos]] =
+        findUtxos(UtxoQuery(UtxoSource.FromAddress(address)))
+
+    /** Map over this reader's effect `F` — the one primitive needed to give the convenience lookups
+      * above ([[findUtxo]] and the `findUtxos` overloads) a single effect-polymorphic default,
+      * without imposing an external Functor/Monad constraint on `F`. Future-based readers map via
+      * their captured ExecutionContext; monadic effects map via their monad.
+      */
+    protected def mapF[A, B](fa: F[A])(f: A => B): F[B]
+
     /** Returns the current slot number.
       */
     def currentSlot: F[SlotNo]
@@ -189,49 +223,9 @@ trait BlockchainReader extends BlockchainReaderTF[Future] {
 
     def fetchLatestParams: Future[ProtocolParams]
 
-    /** Find a single UTxO by its transaction input.
-      *
-      * @param input
-      *   the transaction input to look up
-      * @return
-      *   Either a UtxoQueryError or the found Utxo
-      */
-    def findUtxo(input: TransactionInput): Future[Either[UtxoQueryError, Utxo]] = {
-        findUtxos(UtxoQuery(UtxoSource.FromInputs(Set(input)))).map { result =>
-            result.flatMap { utxos =>
-                utxos.headOption match
-                    case Some((i, o)) => Right(Utxo(i, o))
-                    case None => Left(UtxoQueryError.NotFound(UtxoSource.FromInputs(Set(input))))
-            }
-        }(using executionContext)
-    }
-
-    /** Find UTxOs by a set of transaction inputs.
-      *
-      * @param inputs
-      *   the transaction inputs to look up
-      * @return
-      *   Either a UtxoQueryError or the found UTxOs (fails if not all inputs are found)
-      */
-    def findUtxos(inputs: Set[TransactionInput]): Future[Either[UtxoQueryError, Utxos]] = {
-        findUtxos(UtxoQuery(UtxoSource.FromInputs(inputs))).map { result =>
-            result.flatMap { foundUtxos =>
-                if foundUtxos.size == inputs.size then Right(foundUtxos)
-                else Left(UtxoQueryError.NotFound(UtxoSource.FromInputs(inputs)))
-            }
-        }(using executionContext)
-    }
-
-    /** Find all UTxOs at the given address.
-      *
-      * @param address
-      *   the address to query
-      * @return
-      *   Either a UtxoQueryError or the found UTxOs
-      */
-    def findUtxos(address: Address): Future[Either[UtxoQueryError, Utxos]] = {
-        findUtxos(UtxoQuery(UtxoSource.FromAddress(address)))
-    }
+    /** Map over the `Future` effect using this reader's captured ExecutionContext. */
+    override protected def mapF[A, B](fa: Future[A])(f: A => B): Future[B] =
+        fa.map(f)(using executionContext)
 
     /** Returns the current slot number.
       */

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/EmulatorBase.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/EmulatorBase.scala
@@ -26,12 +26,37 @@ trait EmulatorBase extends BlockchainProvider {
     def certState: CertState
     protected def currentContext: Context
     def datums: Map[DataHash, Data]
+
+    /** Index of applied transactions by hash, for O(1) lookup. Platform-specific state. */
+    def appliedTxIndex: Map[TransactionHash, AppliedTx]
+
+    /** Ordered log of transactions applied to this emulator, in submission order (oldest first).
+      *
+      * Unlike [[appliedTxs]] (hashes only), each entry retains the full transaction together with
+      * the slot it was applied at and the inputs it consumed (resolved against the pre-application
+      * UTxO set). This lets callers reconstruct chain history — e.g. walk the continuing outputs of
+      * an asset — without keeping their own submitted-transaction bookkeeping.
+      *
+      * Ordering reflects submission order; under concurrent submission it is best-effort — the
+      * underlying ledger state transition is serialized, but the log append that follows it is not.
+      */
+    def appliedTxLog: Seq[AppliedTx]
+
+    /** Hashes of all applied transactions. Held as a materialized set (kept in sync with
+      * [[appliedTxIndex]] by the platform implementations) so access is a plain O(1) field read
+      * rather than a per-call key-set view.
+      */
     def appliedTxs: Set[TransactionHash]
 
     // Abstract - platform-specific state modification
     def submitSync(transaction: Transaction): Either[SubmitError, TransactionHash]
     def setSlot(slot: SlotNo): Unit
     def snapshot(): Emulator
+
+    /** Clear the applied-transaction bookkeeping ([[appliedTxLog]] and [[appliedTxIndex]]), leaving
+      * the ledger state (`utxos`, `certState`, `datums`) untouched.
+      */
+    def clearAppliedTxs(): Unit
 
     /** Evaluator mode the emulator runs Plutus scripts in (e.g. `Validate` vs
       * `EvaluateAndComputeCost`). Exposed so snapshots such as `ImmutableEmulator.fromEmulator` can
@@ -41,7 +66,15 @@ trait EmulatorBase extends BlockchainProvider {
 
     def tick(n: Long): Unit = setSlot(currentContext.env.slot + n)
 
-    def hasTx(txHash: TransactionHash): Boolean = appliedTxs.contains(txHash)
+    def hasTx(txHash: TransactionHash): Boolean = appliedTxIndex.contains(txHash)
+
+    /** Look up a previously applied transaction by hash, or `None` if it was never applied. */
+    def getTransaction(txHash: TransactionHash): Option[Transaction] =
+        appliedTxIndex.get(txHash).map(_.tx)
+
+    /** Look up the full applied-tx record (transaction + slot + spent inputs) by hash. */
+    def getAppliedTx(txHash: TransactionHash): Option[AppliedTx] =
+        appliedTxIndex.get(txHash)
 
     def getDelegation(credential: Credential): DelegationInfo = {
         val st = certState.dstate
@@ -101,6 +134,23 @@ trait EmulatorBase extends BlockchainProvider {
     ): Either[TransactionException, State] = {
         STS.Mutator.transit(validators, mutators, context, state, transaction)
     }
+}
+
+/** A record of a transaction applied to the emulated ledger.
+  *
+  * Captures the parts of chain history that the live UTxO set no longer holds after application:
+  * the full transaction, the slot it was applied at, and the resolved inputs it consumed (which are
+  * removed from the UTxO set once the transaction is applied).
+  *
+  * @param tx
+  *   the applied transaction
+  * @param slot
+  *   the emulator slot at the time of application
+  * @param spent
+  *   the UTxOs consumed by `tx`, resolved against the pre-application UTxO set
+  */
+case class AppliedTx(tx: Transaction, slot: SlotNo, spent: Utxos) {
+    def txHash: TransactionHash = tx.id
 }
 
 case class DelegationInfo(poolId: Option[PoolKeyHash], rewards: Coin)
@@ -195,6 +245,23 @@ object EmulatorBase {
             Input(genesisHash, index) -> Output(address, initialValue)
         }.toMap
     }
+
+    /** Resolve the inputs a transaction consumes against a UTxO set.
+      *
+      * Returns the subset of `utxos` whose inputs appear in `transaction`'s input set — i.e. the
+      * UTxOs that applying the transaction will remove. Intended to be evaluated against the
+      * pre-application snapshot so the consumed values can be retained in [[AppliedTx]].
+      */
+    def resolveSpent(utxos: Utxos, transaction: Transaction): Utxos =
+        transaction.body.value.inputs.toSeq.view
+            .flatMap(input => utxos.get(input).map(input -> _))
+            .toMap
+
+    /** Build the by-hash index for an applied-tx log — the single place this derivation lives, so
+      * an emulator's index and its log cannot drift apart.
+      */
+    def indexAppliedTxs(log: Iterable[AppliedTx]): Map[TransactionHash, AppliedTx] =
+        log.iterator.map(a => a.txHash -> a).toMap
 
     def extractDatums(transaction: Transaction): Map[DataHash, Data] = {
         val fromWitness = transaction.witnessSet.plutusData.value.toMap.map {

--- a/scalus-testkit/jvm/src/test/scala/scalus/testing/ImmutableEmulatorTest.scala
+++ b/scalus-testkit/jvm/src/test/scala/scalus/testing/ImmutableEmulatorTest.scala
@@ -2,10 +2,17 @@ package scalus.testing
 
 import org.scalatest.funsuite.AnyFunSuite
 import scalus.cardano.ledger.*
-import scalus.cardano.ledger.rules.Context
+import scalus.cardano.ledger.rules.{Context, State, UtxoEnv}
 import scalus.cardano.node.Emulator
+import scalus.cardano.txbuilder.TxBuilder
+import scalus.testing.kit.Party.{Alice, Bob}
+import scalus.uplc.PlutusV3
+import scalus.uplc.builtin.{ByteString, Data}
+import scalus.utils.await
 
 class ImmutableEmulatorTest extends AnyFunSuite {
+
+    given CardanoInfo = CardanoInfo.mainnet
 
     test("fromEmulator carries over evaluatorMode (issue #314)") {
         val emulator = Emulator(
@@ -32,5 +39,149 @@ class ImmutableEmulatorTest extends AnyFunSuite {
 
         assert(immutable.currentSlot == 100L)
         assert(immutable.evaluatorMode == EvaluatorMode.EvaluateAndComputeCost)
+    }
+
+    test("submit appends to the applied-transaction log; original is unchanged") {
+        val genesisHash =
+            TransactionHash.fromByteString(ByteString.fromHex("0" * 64))
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val emu = ImmutableEmulator(
+          state = State(utxos = initialUtxos),
+          env = UtxoEnv.testMainnet(),
+          validators = Set.empty
+        ).setSlot(7L)
+
+        assert(emu.appliedTxLog.isEmpty, "log should start empty")
+
+        val tx = TxBuilder(CardanoInfo.mainnet)
+            .payTo(Bob.address, Value.ada(10))
+            .complete(emu.asReader, Alice.address)
+            .await()
+            .transaction
+
+        emu.submit(tx) match
+            case Right((hash, next)) =>
+                assert(hash == tx.id)
+                assert(next.appliedTxLog.size == 1)
+                assert(next.appliedTxLog.head.slot == 7L)
+                assert(next.appliedTxLog.head.spent == initialUtxos)
+                assert(next.getTransaction(tx.id).contains(tx))
+                assert(next.appliedTxIndex.keySet == Set(tx.id))
+                assert(next.getAppliedTx(tx.id).map(_.slot).contains(7L))
+                assert(next.hasTx(tx.id))
+                // immutability: the original emulator keeps an empty log
+                assert(emu.appliedTxLog.isEmpty, "original emulator must be unchanged")
+            case Left(e) => fail(s"submit failed: $e")
+    }
+
+    test("fromEmulator and toEmulator preserve certState") {
+        val stakeCred = Credential.ScriptHash(PlutusV3.alwaysOk.script.scriptHash)
+        val reward = Coin(42_000_000L)
+        val emulator = Emulator.withRegisteredStakeCredentials(
+          initialUtxos = Map.empty,
+          initialStakeRewards = Map(stakeCred -> reward)
+        )
+        assert(emulator.certState.dstate.rewards.get(stakeCred).contains(reward))
+
+        val immutable = ImmutableEmulator.fromEmulator(emulator)
+        assert(
+          immutable.state.certState.dstate.rewards.get(stakeCred).contains(reward),
+          "fromEmulator must carry over certState"
+        )
+
+        val roundTripped = immutable.toEmulator
+        assert(
+          roundTripped.certState.dstate.rewards.get(stakeCred).contains(reward),
+          "toEmulator must carry over certState"
+        )
+    }
+
+    test("toEmulator reconstructs datums and index from the applied-tx log") {
+        val genesisHash = TransactionHash.fromByteString(ByteString.fromHex("0" * 64))
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val provider = Emulator(
+          initialUtxos = initialUtxos,
+          validators = Set.empty,
+          mutators = Emulator.defaultMutators
+        )
+        val tx = TxBuilder(CardanoInfo.mainnet)
+            .payTo(Bob.address, Value.ada(10), (_: Transaction) => Data.unit)
+            .complete(provider, Alice.address)
+            .await()
+            .transaction
+        assert(provider.submit(tx).await().isRight)
+        assert(provider.datums.nonEmpty, "sanity: the submitted tx carried an inline datum")
+
+        // ImmutableEmulator has no separate datum store, so datums must be recovered from the
+        // applied-tx log when converting back to a mutable Emulator.
+        val rebuilt = ImmutableEmulator.fromEmulator(provider).toEmulator
+        assert(rebuilt.appliedTxs == provider.appliedTxs)
+        assert(rebuilt.datums == provider.datums, "toEmulator must reconstruct datums from the log")
+        assert(rebuilt.getTransaction(tx.id).contains(tx))
+    }
+
+    test("clearAppliedTxs resets the immutable log/index, keeping ledger state") {
+        val genesisHash = TransactionHash.fromByteString(ByteString.fromHex("0" * 64))
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val emu = ImmutableEmulator(
+          state = State(utxos = initialUtxos),
+          env = UtxoEnv.testMainnet(),
+          validators = Set.empty
+        )
+        val tx = TxBuilder(CardanoInfo.mainnet)
+            .payTo(Bob.address, Value.ada(10))
+            .complete(emu.asReader, Alice.address)
+            .await()
+            .transaction
+        val next = emu.submit(tx) match
+            case Right((_, e)) => e
+            case Left(e)       => fail(s"submit failed: $e")
+        assert(next.appliedTxLog.nonEmpty && next.appliedTxIndex.nonEmpty)
+
+        val cleared = next.clearAppliedTxs
+        assert(cleared.appliedTxLog.isEmpty)
+        assert(cleared.appliedTxIndex.isEmpty)
+        assert(cleared.getTransaction(tx.id).isEmpty)
+        assert(!cleared.hasTx(tx.id))
+        assert(cleared.utxos == next.utxos, "ledger state must be untouched")
+    }
+
+    test("ImmutableEmulator retains and resolves datums; clearAppliedTxs keeps them") {
+        val genesisHash = TransactionHash.fromByteString(ByteString.fromHex("0" * 64))
+        val initialUtxos = Map(
+          Input(genesisHash, 0) -> Output(Alice.address, Value.ada(100))
+        )
+        val emu = ImmutableEmulator(
+          state = State(utxos = initialUtxos),
+          env = UtxoEnv.testMainnet(),
+          validators = Set.empty
+        )
+        val tx = TxBuilder(CardanoInfo.mainnet)
+            .payTo(Bob.address, Value.ada(10), (_: Transaction) => Data.unit)
+            .complete(emu.asReader, Alice.address)
+            .await()
+            .transaction
+        val next = emu.submit(tx) match
+            case Right((_, e)) => e
+            case Left(e)       => fail(s"submit failed: $e")
+
+        assert(next.datums.nonEmpty, "submit must retain the inline datum")
+        val (dh, d) = next.datums.head
+        assert(next.getDatum(dh).contains(d), "getDatum resolves the datum")
+        assert(
+          next.asReader.getDatum(dh).await().contains(d),
+          "asReader resolves it (was always None before)"
+        )
+
+        // clearAppliedTxs wipes history but keeps the datum resolution cache
+        val cleared = next.clearAppliedTxs
+        assert(cleared.appliedTxLog.isEmpty)
+        assert(cleared.getDatum(dh).contains(d), "datums survive clearAppliedTxs")
     }
 }

--- a/scalus-testkit/jvm/src/test/scala/scalus/testing/ScenarioTest.scala
+++ b/scalus-testkit/jvm/src/test/scala/scalus/testing/ScenarioTest.scala
@@ -55,6 +55,23 @@ class ScenarioTest extends AnyFunSuite {
         assert(result.get._2 == initial.emulator.currentSlot + 5)
     }
 
+    test("provider.findUtxo and findUtxos(address) resolve through the Scenario monad") {
+        val initial = mkState(Alice, Bob)
+        val aliceInput = initial.emulator.utxos.collectFirst {
+            case (in, out) if out.address == Alice.address => in
+        }.get
+        val m = Scenario.scenarioLogicMonad
+        val scenario = m.flatMap(Scenario.provider) { p =>
+            m.flatMap(p.findUtxo(aliceInput)) { byInput =>
+                m.map(p.findUtxos(Alice.address))(byAddr => (byInput, byAddr))
+            }
+        }
+        val (byInput, byAddr) = awaitResult(Scenario.continueFirst(initial)(scenario)).get._2
+        assert(byInput.isRight, s"findUtxo should resolve: $byInput")
+        assert(byInput.toOption.get.output.address == Alice.address)
+        assert(byAddr.isRight && byAddr.toOption.exists(_.nonEmpty), s"findUtxos(address): $byAddr")
+    }
+
     // =========================================================================
     // Non-deterministic branching
     // =========================================================================

--- a/scalus-testkit/shared/src/main/scala/scalus/testing/ImmutableEmulator.scala
+++ b/scalus-testkit/shared/src/main/scala/scalus/testing/ImmutableEmulator.scala
@@ -23,7 +23,18 @@ case class ImmutableEmulator(
     slotConfig: SlotConfig = SlotConfig.mainnet,
     evaluatorMode: EvaluatorMode = EvaluatorMode.Validate,
     validators: Iterable[STS.Validator] = Emulator.defaultValidators,
-    mutators: Iterable[STS.Mutator] = Emulator.defaultMutators
+    mutators: Iterable[STS.Mutator] = Emulator.defaultMutators,
+    /** Ordered log of applied transactions (oldest first); maintained by [[submit]]. */
+    appliedTxLog: Vector[AppliedTx] = Vector.empty,
+    /** By-hash index of [[appliedTxLog]] for O(1) lookup. Invariant: the by-hash view of
+      * `appliedTxLog`; both advance together in [[submit]]. Build it via
+      * `EmulatorBase.indexAppliedTxs` rather than setting it independently.
+      */
+    appliedTxIndex: Map[TransactionHash, AppliedTx] = Map.empty,
+    /** Datum resolution cache (inline + witness datums of applied transactions). Maintained by
+      * [[submit]] so [[getDatum]] and [[asReader]] can resolve datum-hash references.
+      */
+    datums: Map[DataHash, Data] = Map.empty
 ) {
 
     /** Current UTxO set. */
@@ -46,11 +57,36 @@ case class ImmutableEmulator(
         val context = Context(env = env, slotConfig = slotConfig, evaluatorMode = evaluatorMode)
         STS.Mutator.transit(validators, mutators, context, state, tx) match {
             case Right(newState) =>
-                Right((tx.id, copy(state = newState)))
+                val applied = AppliedTx(tx, env.slot, EmulatorBase.resolveSpent(state.utxos, tx))
+                val next = copy(
+                  state = newState,
+                  appliedTxLog = appliedTxLog :+ applied,
+                  appliedTxIndex = appliedTxIndex + (applied.txHash -> applied),
+                  datums = datums ++ EmulatorBase.extractDatums(tx)
+                )
+                Right((tx.id, next))
             case Left(e: TransactionException) =>
                 Left(SubmitError.fromException(e))
         }
     }
+
+    /** True if the given transaction has been applied to this emulator. */
+    def hasTx(txHash: TransactionHash): Boolean = appliedTxIndex.contains(txHash)
+
+    /** Look up a previously applied transaction by hash, or `None` if it was never applied. */
+    def getTransaction(txHash: TransactionHash): Option[Transaction] =
+        appliedTxIndex.get(txHash).map(_.tx)
+
+    /** Look up the full applied-tx record (transaction + slot + spent inputs) by hash. */
+    def getAppliedTx(txHash: TransactionHash): Option[AppliedTx] =
+        appliedTxIndex.get(txHash)
+
+    /** Resolve a datum by its hash, or `None` if unknown. */
+    def getDatum(datumHash: DataHash): Option[Data] = datums.get(datumHash)
+
+    /** Clear the applied-transaction bookkeeping (log + index), keeping ledger state. */
+    def clearAppliedTxs: ImmutableEmulator =
+        copy(appliedTxLog = Vector.empty, appliedTxIndex = Map.empty)
 
     /** Advance the slot by the given number of slots. */
     def advanceSlot(n: Long): ImmutableEmulator = copy(env = env.copy(slot = env.slot + n))
@@ -78,7 +114,7 @@ case class ImmutableEmulator(
         override def currentSlot: Future[SlotNo] =
             Future.successful(env.slot)
         def getDatum(datumHash: DataHash): Future[Option[Data]] =
-            Future.successful(None)
+            Future.successful(ImmutableEmulator.this.datums.get(datumHash))
     }
 
     /** Convert to a mutable [[scalus.cardano.node.Emulator]]. */
@@ -88,7 +124,10 @@ case class ImmutableEmulator(
           initialUtxos = utxos,
           initialContext = context,
           validators = validators,
-          mutators = mutators
+          mutators = mutators,
+          initialCertState = state.certState,
+          initialDatums = datums,
+          initialAppliedTxLog = appliedTxLog
         )
     }
 }
@@ -106,16 +145,22 @@ object ImmutableEmulator {
         val env = UtxoEnv(
           slot = slot,
           params = info.protocolParams,
+          // ledger rules read cert state from `state.certState`, not `env.certState`; mirror the
+          // mutable Emulator and keep this empty (the real cert state lives in `state` below)
           certState = CertState.empty,
           network = info.network
         )
+        val log = emulator.appliedTxLog.toVector
         ImmutableEmulator(
-          state = State(utxos = emulator.utxos),
+          state = State(utxos = emulator.utxos, certState = emulator.certState),
           env = env,
           slotConfig = info.slotConfig,
           evaluatorMode = emulator.evaluatorMode,
           validators = emulator.validators,
-          mutators = emulator.mutators
+          mutators = emulator.mutators,
+          appliedTxLog = log,
+          appliedTxIndex = EmulatorBase.indexAppliedTxs(log),
+          datums = emulator.datums
         )
     }
 

--- a/scalus-testkit/shared/src/main/scala/scalus/testing/Scenario.scala
+++ b/scalus-testkit/shared/src/main/scala/scalus/testing/Scenario.scala
@@ -343,6 +343,9 @@ object Scenario {
             ): Scenario[Either[UtxoQueryError, Utxos]] =
                 leaf(s => Done(s, s.emulator.findUtxos(query)))
 
+            override protected def mapF[A, B](fa: Scenario[A])(f: A => B): Scenario[B] =
+                scenarioLogicMonad.map(fa)(f)
+
             override def currentSlot: Scenario[SlotNo] =
                 Scenario.now
 


### PR DESCRIPTION
## Summary

Extends the Scalus `Emulator` / `BlockchainProvider` toward use as a full backend (e.g. for a Hydrozoa test/prod backend), in two parts.

### Emulator: applied-transaction log + hash index
- New `AppliedTx(tx, slot, spent)` — each applied transaction with the slot it was applied at and the inputs it consumed (resolved against the pre-application UTxO set, since they're gone from the live set afterward).
- Ordered `appliedTxLog` + by-hash `appliedTxIndex`; `getTransaction` / `getAppliedTx` / `hasTx` are O(1). `appliedTxs` stays a materialized set (O(1) field read). `clearAppliedTxs` resets the log/index while keeping `utxos` / `certState` / `datums`. The index is derived through a single shared `EmulatorBase.indexAppliedTxs`, so it can't drift from the log.
- Round-trip fixes: `ImmutableEmulator.fromEmulator` / `toEmulator` now preserve `certState`, and `ImmutableEmulator` keeps a datum cache so `getDatum` / `asReader` resolve datums instead of always returning `None` (datums were previously lost on the round-trip).
- `resolveSpent` iterates the (small) input set instead of scanning the whole UTxO set.

### Provider: effect-polymorphic findUtxo
- `findUtxo(input)`, `findUtxos(inputs)`, `findUtxos(address)` move from the `Future`-only `BlockchainReader` up to `BlockchainReaderTF[F]`, so they work for any effect (e.g. the `Scenario` monad), not just `Future`. They share one new `mapF` primitive — the only capability needed to map over `F` without imposing an external Functor/Monad constraint; `BlockchainReader` provides it via its captured ExecutionContext, the Scenario provider via its monad.

## Testing
- `sbt jvm/testQuick` green (incl. `scalus-examples`, `TxBuilder`, `Scenario`, and emulator suites); JVM + JS compile; scalafmt clean.
- New tests: emulator applied-tx log / index / `clearAppliedTxs` / datum round-trip, `certState` round-trip, and `findUtxo` / `findUtxos(address)` through the `Scenario`-typed provider.

## Notes
- No MiMa impact — `scalus-cardano-ledger` and `scalus-testkit` aren't binary-compatibility checked; every new constructor param / field is defaulted, so the change is source-compatible.
